### PR TITLE
fix: bot権限以上のロールのグレーアウト化、UI調整

### DIFF
--- a/backend/app/api/v1/manifest.py
+++ b/backend/app/api/v1/manifest.py
@@ -31,6 +31,7 @@ class Role(BaseModel):
 	permissions: int = 0
 	position: int
 	category_id: str | None = None
+	is_our_bot: bool = False
 
 
 class Manifest(BaseModel):

--- a/backend/app/api/v1/roles.py
+++ b/backend/app/api/v1/roles.py
@@ -66,6 +66,7 @@ async def push_roles_to_discord(_principal: dict = Depends(get_current_principal
 	created = 0
 	deleted = 0
 	skipped_managed = 0
+	errors = []
 
 	for role in desired_roles:
 		role_id = role["role_id"]
@@ -80,8 +81,14 @@ async def push_roles_to_discord(_principal: dict = Depends(get_current_principal
 					await asyncio.to_thread(update_role_id, role_id, real_id)
 					# Update our local mapping so the real role isn't accidentally deleted below
 					desired_by_id[real_id] = role
-			except Exception:
-				pass
+					role["role_id"] = real_id
+					actual_by_id[real_id] = new_role_discord
+			except Exception as exc:
+				msg = f"Failed to create role locally {role_id}: {exc}"
+				print(msg)
+				errors.append(msg)
+				import traceback
+				traceback.print_exc()
 			continue
 		if actual.get("managed") or role_id == DISCORD_GUILD_ID:
 			skipped_managed += 1
@@ -92,8 +99,10 @@ async def push_roles_to_discord(_principal: dict = Depends(get_current_principal
 		try:
 			await edit_guild_role(DISCORD_GUILD_ID, role_id, token, payload)
 			updated += 1
-		except Exception:
-			pass
+		except Exception as exc:
+			msg = f"Failed to update role in discord {role_id}: {exc}"
+			print(msg)
+			errors.append(msg)
 
 	for role in actual_roles:
 		role_id = role["role_id"]
@@ -104,30 +113,38 @@ async def push_roles_to_discord(_principal: dict = Depends(get_current_principal
 		try:
 			await delete_guild_role(DISCORD_GUILD_ID, role_id, token)
 			deleted += 1
-		except Exception:
-			pass
+		except Exception as exc:
+			msg = f"Failed to delete role {role_id}: {exc}"
+			print(msg)
+			errors.append(msg)
 
-	position_payload = [
-		{"id": role["role_id"], "position": int(role.get("position", 0))}
-		for role in sorted(desired_roles, key=lambda x: int(x.get("position", 0)))
-		if role["role_id"] in actual_by_id and role["role_id"] != DISCORD_GUILD_ID
-	]
+	desired_roles_sorted = sorted(desired_roles, key=lambda x: int(x.get("position", 0)))
+	position_payload = []
+	current_pos = 1
+	for role in desired_roles_sorted:
+		if role["role_id"] in actual_by_id and role["role_id"] != DISCORD_GUILD_ID:
+			position_payload.append({"id": role["role_id"], "position": current_pos})
+			current_pos += 1
 	reordered = 0
 	if position_payload:
 		try:
 			await reorder_guild_roles(DISCORD_GUILD_ID, token, position_payload)
 			reordered = len(position_payload)
-		except Exception:
+		except Exception as exc:
+			msg = f"Failed to reorder roles: {exc}"
+			print(msg)
+			errors.append(msg)
 			reordered = 0
 
 	return {
-		"ok": True,
+		"ok": len(errors) == 0,
 		"guild_id": DISCORD_GUILD_ID,
 		"updated": updated,
 		"created": created,
 		"deleted": deleted,
 		"reordered": reordered,
 		"skipped_managed": skipped_managed,
+		"errors": errors,
 	}
 
 

--- a/backend/app/db/repository.py
+++ b/backend/app/db/repository.py
@@ -51,6 +51,12 @@ def init_db() -> None:
 				);
 				"""
 			)
+			cur.execute(
+				"""
+				ALTER TABLE role_manifests
+				ADD COLUMN IF NOT EXISTS is_our_bot BOOLEAN DEFAULT FALSE;
+				"""
+			)
 
 
 def fetch_manifest() -> dict[str, list[dict[str, Any]]]:
@@ -76,7 +82,7 @@ def fetch_manifest() -> dict[str, list[dict[str, Any]]]:
 
 			cur.execute(
 				"""
-				SELECT role_id, name, color, hoist, mentionable, permissions, position, category_id
+				SELECT role_id, name, color, hoist, mentionable, permissions, position, category_id, is_our_bot
 				FROM role_manifests
 				ORDER BY position DESC, name ASC
 				"""
@@ -91,6 +97,7 @@ def fetch_manifest() -> dict[str, list[dict[str, Any]]]:
 					"permissions": int(row[5]),
 					"position": row[6],
 					"category_id": row[7],
+					"is_our_bot": bool(row[8]),
 				}
 				for row in cur.fetchall()
 			]
@@ -122,8 +129,8 @@ def save_manifest(categories: list[dict[str, Any]], roles: list[dict[str, Any]])
 				cur.execute(
 					"""
 					INSERT INTO role_manifests
-					(role_id, name, color, hoist, mentionable, permissions, position, category_id)
-					VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+					(role_id, name, color, hoist, mentionable, permissions, position, category_id, is_our_bot)
+					VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
 					""",
 					(
 						r["role_id"],
@@ -134,6 +141,7 @@ def save_manifest(categories: list[dict[str, Any]], roles: list[dict[str, Any]])
 						int(r.get("permissions", 0)),
 						r["position"],
 						r.get("category_id"),
+						r.get("is_our_bot", False),
 					),
 				)
 
@@ -141,13 +149,26 @@ def save_manifest(categories: list[dict[str, Any]], roles: list[dict[str, Any]])
 def replace_roles_from_discord(roles: list[dict[str, Any]]) -> int:
 	with _connect() as conn:
 		with conn.cursor() as cur:
-			cur.execute("DELETE FROM role_manifests")
+			existing_ids = tuple(role["role_id"] for role in roles)
+			if existing_ids:
+				cur.execute("DELETE FROM role_manifests WHERE role_id NOT IN %s", (existing_ids,))
+			else:
+				cur.execute("DELETE FROM role_manifests")
+				
 			for role in roles:
 				cur.execute(
 					"""
 					INSERT INTO role_manifests
-					(role_id, name, color, hoist, mentionable, permissions, position, category_id)
+					(role_id, name, color, hoist, mentionable, permissions, position, is_our_bot)
 					VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+					ON CONFLICT (role_id) DO UPDATE SET
+						name = EXCLUDED.name,
+						color = EXCLUDED.color,
+						hoist = EXCLUDED.hoist,
+						mentionable = EXCLUDED.mentionable,
+						permissions = EXCLUDED.permissions,
+						position = EXCLUDED.position,
+						is_our_bot = EXCLUDED.is_our_bot
 					""",
 					(
 						role["role_id"],
@@ -157,7 +178,7 @@ def replace_roles_from_discord(roles: list[dict[str, Any]]) -> int:
 						role["mentionable"],
 						role["permissions"],
 						role["position"],
-						None,
+						role.get("is_our_bot", False),
 					),
 				)
 	return len(roles)

--- a/backend/app/services/discord_client.py
+++ b/backend/app/services/discord_client.py
@@ -25,8 +25,13 @@ async def fetch_guild_roles(guild_id: str, token: str) -> list[dict]:
 	headers = {"Authorization": f"Bot {token}"}
 	url = f"{DISCORD_API_BASE}/guilds/{guild_id}/roles"
 	async with httpx.AsyncClient(timeout=10.0) as client:
+		# Get the bot's own user ID to identify our bot role
+		me_resp = await client.get(f"{DISCORD_API_BASE}/users/@me", headers=headers)
+		me_resp.raise_for_status()
+		bot_id = me_resp.json()["id"]
+
 		response = await client.get(url, headers=headers)
-	response.raise_for_status()
+		response.raise_for_status()
 
 	roles = response.json()
 	return [
@@ -39,6 +44,7 @@ async def fetch_guild_roles(guild_id: str, token: str) -> list[dict]:
 			"permissions": int(role.get("permissions", "0")),
 			"position": int(role.get("position", 0)),
 			"managed": bool(role.get("managed", False)),
+			"is_our_bot": (role.get("tags") or {}).get("bot_id") == bot_id,
 		}
 		for role in roles
 	]

--- a/frontend/src/app/(admin)/roles/page.tsx
+++ b/frontend/src/app/(admin)/roles/page.tsx
@@ -3,8 +3,6 @@
 import { auth } from "@/auth";
 import { fetchManifest } from "@/actions/manifest";
 import RoleAccordion from "@/components/roles/RoleAccordion";
-import SyncButton from "@/components/roles/SyncButton";
-import PushButton from "@/components/roles/PushButton";
 import { redirect } from "next/navigation";
 
 type RolesPageProps = {
@@ -81,10 +79,6 @@ export default async function RolesPage({ searchParams }: RolesPageProps) {
 					<a href="/api/auth/signout?callbackUrl=%2F">sign out</a>)
 				</p>
 			) : null}
-			<div style={{ display: "flex", gap: 8 }}>
-				<SyncButton />
-				<PushButton />
-			</div>
 			{synced && !hasError ? (
 				<p style={{ marginTop: 12, color: "#166534" }}>同期完了: {syncedRoles} 件のロールを更新しました。</p>
 			) : null}

--- a/frontend/src/app/api/roles/push/route.ts
+++ b/frontend/src/app/api/roles/push/route.ts
@@ -26,6 +26,7 @@ export async function POST() {
 			reordered?: number;
 			guild_id?: string;
 			detail?: string;
+			errors?: string[];
 		};
 		return NextResponse.json(body, { status: res.status });
 	} catch {

--- a/frontend/src/components/roles/NewRoleModal.tsx
+++ b/frontend/src/components/roles/NewRoleModal.tsx
@@ -21,10 +21,12 @@ type NewRoleData = {
   permissions: number;
   position: number;
   category_id: string | null;
+  is_our_bot?: boolean;
 };
 
 type Props = {
   categories: Category[];
+  botPermissions: bigint;
   onCreated: (role: NewRoleData) => void;
   onClose: () => void;
 };
@@ -44,7 +46,7 @@ function setBit(perms: bigint, bit: bigint, value: boolean): bigint {
   return value ? perms | (1n << bit) : perms & ~(1n << bit);
 }
 
-export default function NewRoleModal({ categories, onCreated, onClose }: Props) {
+export default function NewRoleModal({ categories, botPermissions, onCreated, onClose }: Props) {
   const [name, setName] = useState("");
   const [color, setColor] = useState("#99AAB5");
   const [hexInput, setHexInput] = useState("#99AAB5");
@@ -80,6 +82,7 @@ export default function NewRoleModal({ categories, onCreated, onClose }: Props) 
   }
 
   const isAdminActive = hasBitExact(perms, 3n);
+  const botHasAdmin = hasBitExact(botPermissions, 3n);
 
   async function handleCreate() {
     if (!name.trim()) {
@@ -111,7 +114,6 @@ export default function NewRoleModal({ categories, onCreated, onClose }: Props) 
             <p className={styles.title}>＋ 新規ロールを作成</p>
             <p className={styles.subtitle}>データベースに下書きとして保存します（Discordへの反映は「送信」を押してください）</p>
           </div>
-          <button type="button" className={styles.closeBtn} onClick={onClose}>✕</button>
         </div>
 
         {/* Tabs */}
@@ -240,21 +242,26 @@ export default function NewRoleModal({ categories, onCreated, onClose }: Props) 
                   {section.perms.map((perm) => {
                     const isEnabled = hasBitExact(perms, perm.bit);
                     const isFromAdmin = isAdminActive && perm.bit !== 3n;
+                    const isBotAllowed = botHasAdmin || hasBitExact(botPermissions, perm.bit);
+
                     return (
                       <div
                         key={String(perm.bit)}
-                        className={`${styles.permRow} ${isFromAdmin ? styles.dimmed : ""}`}
+                        className={`${styles.permRow} ${isFromAdmin ? styles.dimmed : ""} ${!isBotAllowed ? styles.disabledRow : ""}`}
                       >
                         <div className={styles.permInfo}>
-                          <div className={styles.permName}>{perm.name}</div>
+                          <div className={styles.permName}>
+                            {perm.name}
+                            {!isBotAllowed && <span className={styles.botLacksMsg}>(Bot権限不足)</span>}
+                          </div>
                           <div className={styles.permDesc}>{perm.description}</div>
                         </div>
                         <label className={styles.switch}>
                           <input
                             type="checkbox"
                             checked={isFromAdmin ? true : isEnabled}
-                            disabled={isFromAdmin}
-                            onChange={() => !isFromAdmin && toggleBit(perm.bit)}
+                            disabled={isFromAdmin || !isBotAllowed}
+                            onChange={() => !isFromAdmin && isBotAllowed && toggleBit(perm.bit)}
                           />
                           <span className={styles.switchSlider} />
                         </label>
@@ -270,7 +277,7 @@ export default function NewRoleModal({ categories, onCreated, onClose }: Props) 
         {/* Footer */}
         <div className={styles.footer}>
           {error && <span className={styles.errorMsg}>✕ {error}</span>}
-          <button type="button" className={styles.cancelBtn} onClick={onClose}>キャンセル</button>
+          <button type="button" className={styles.cancelBtn} onClick={onClose}>戻る</button>
           <button
             type="button"
             className={styles.createBtn}

--- a/frontend/src/components/roles/PermissionEditor.tsx
+++ b/frontend/src/components/roles/PermissionEditor.tsx
@@ -74,6 +74,7 @@ export type PermissionTarget = {
 
 type Props = {
   target: PermissionTarget;
+  botPermissions: bigint;
   onSave: (newPermissions: number) => void;
   onClose: () => void;
 };
@@ -96,10 +97,11 @@ function setBit(perms: bigint, bit: bigint, value: boolean): bigint {
 
 // ===== Main Component =====
 
-export default function PermissionEditorPanel({ target, onSave, onClose }: Props) {
+export default function PermissionEditorPanel({ target, botPermissions, onSave, onClose }: Props) {
   const [perms, setPerms] = useState<bigint>(BigInt(target.currentPermissions));
   const catPerms = BigInt(target.categoryPermissions ?? 0);
   const isAdminActive = hasBitExact(perms, 3n);
+  const botHasAdmin = hasBitExact(botPermissions, 3n);
 
   useEffect(() => {
     setPerms(BigInt(target.currentPermissions));
@@ -136,18 +138,10 @@ export default function PermissionEditorPanel({ target, onSave, onClose }: Props
               {target.kind === "category" ? "📁 " : "🏷 "}
               {target.name}
             </p>
-            <p className={styles.panelSubtitle}>
-              {target.kind === "category"
-                ? "このカテゴリに含まれるロールのデフォルト権限"
-                : "このロール個別の権限設定"}
-            </p>
             {target.kind === "role" && target.categoryPermissions !== undefined && (
               <span className={styles.categoryBadge}>カテゴリ権限を参照中</span>
             )}
           </div>
-          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="閉じる">
-            ✕
-          </button>
         </div>
 
         {/* Body */}
@@ -176,6 +170,10 @@ export default function PermissionEditorPanel({ target, onSave, onClose }: Props
               {section.perms.map((perm) => {
                 const isEnabled = hasBitExact(perms, perm.bit);
                 const isFromAdmin = isAdminActive && perm.bit !== 3n;
+
+                // --- BOT PERMISSION CHECK ---
+                const isBotAllowed = botHasAdmin || hasBitExact(botPermissions, perm.bit);
+
                 const isInheritedFromCat =
                   target.kind === "role" &&
                   target.categoryPermissions !== undefined &&
@@ -184,10 +182,13 @@ export default function PermissionEditorPanel({ target, onSave, onClose }: Props
                 return (
                   <div
                     key={String(perm.bit)}
-                    className={`${styles.permRow} ${isFromAdmin ? styles.inherited : ""}`}
+                    className={`${styles.permRow} ${isFromAdmin ? styles.inherited : ""} ${!isBotAllowed ? styles.disabledRow : ""}`}
                   >
                     <div className={styles.permInfo}>
-                      <div className={styles.permName}>{perm.name}</div>
+                      <div className={styles.permName}>
+                        {perm.name}
+                        {!isBotAllowed && <span className={styles.botLacksMsg}>(Bot権限不足)</span>}
+                      </div>
                       <div className={styles.permDesc}>{perm.description}</div>
                     </div>
                     {isInheritedFromCat && !isFromAdmin && (
@@ -197,8 +198,8 @@ export default function PermissionEditorPanel({ target, onSave, onClose }: Props
                       <input
                         type="checkbox"
                         checked={isFromAdmin ? true : isEnabled}
-                        disabled={isFromAdmin}
-                        onChange={() => !isFromAdmin && toggleBit(perm.bit)}
+                        disabled={isFromAdmin || !isBotAllowed}
+                        onChange={() => !isFromAdmin && isBotAllowed && toggleBit(perm.bit)}
                         aria-label={perm.name}
                       />
                       <span className={styles.toggleSlider} />
@@ -211,12 +212,9 @@ export default function PermissionEditorPanel({ target, onSave, onClose }: Props
         </div>
 
         {/* Footer */}
-        <div className={styles.panelFooter}>
-          <span className={styles.footerHint}>
-            変更は「保存する」フロートバーで確定されます
-          </span>
+        <div className={styles.footer}>
           <button type="button" className={styles.cancelBtn} onClick={onClose}>
-            キャンセル
+            戻る
           </button>
           <button
             type="button"

--- a/frontend/src/components/roles/PushButton.tsx
+++ b/frontend/src/components/roles/PushButton.tsx
@@ -10,11 +10,12 @@ type PushResult = {
   created?: number;
   deleted?: number;
   reordered?: number;
+  errors?: string[];
 };
 
 type Props = {
   onSuccess?: (result: PushResult) => void;
-  onError?: () => void;
+  onError?: (errors?: string[]) => void;
 };
 
 export default function PushButton({ onSuccess, onError }: Props) {
@@ -33,9 +34,10 @@ export default function PushButton({ onSuccess, onError }: Props) {
         created?: number;
         deleted?: number;
         reordered?: number;
+        errors?: string[];
       };
       if (!res.ok || !body.ok) {
-        onError?.();
+        onError?.(body.errors);
         return;
       }
       onSuccess?.({

--- a/frontend/src/components/roles/RoleAccordion.tsx
+++ b/frontend/src/components/roles/RoleAccordion.tsx
@@ -209,7 +209,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
 
   // ===== SyncButton / PushButton =====
   function handleSyncSuccess(count: number) {
-    showStatus({ kind: "success", msg: `Discord から ${count} 件のロールを取得しました` });
+    window.location.href = `/roles?synced=1&roles=${count}&t=${Date.now()}`;
   }
   function handleSyncError() {
     showStatus({ kind: "error", msg: "Discord からの取得に失敗しました" });
@@ -221,10 +221,14 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     if (result.deleted) parts.push(`削除 ${result.deleted}`);
     if (result.reordered) parts.push(`並び替え ${result.reordered}`);
     const detail = parts.length ? `（${parts.join(" / ")}）` : "";
-    showStatus({ kind: "success", msg: `Discord への送信が完了しました${detail}` });
+    window.location.href = `/roles?pushed=1&updated=${result.updated ?? 0}&created=${result.created ?? 0}&deleted=${result.deleted ?? 0}&reordered=${result.reordered ?? 0}&t=${Date.now()}`;
   }
-  function handlePushError() {
-    showStatus({ kind: "error", msg: "Discord への送信に失敗しました" });
+  function handlePushError(errors?: string[]) {
+    if (errors && errors.length > 0) {
+      showStatus({ kind: "error", msg: `Discord への送信エラー: ${errors[0]}` });
+    } else {
+      showStatus({ kind: "error", msg: "Discord への送信に失敗しました" });
+    }
   }
 
   // ===== Permission panel callbacks =====
@@ -276,11 +280,11 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
   function handleRoleCreated(role: {
     role_id: string; name: string; color: string;
     hoist: boolean; mentionable: boolean; permissions: number;
-    position: number; category_id: string | null;
+    position: number; category_id: string | null; is_our_bot?: boolean;
   }) {
-    setAllRoles((prev) => [role, ...prev]);
+    setAllRoles((prev) => [...prev, role]);
     setShowNewRole(false);
-    showStatus({ kind: "success", msg: `ロール「${role.name}」をDiscordに作成しました！` });
+    showStatus({ kind: "success", msg: `ロール「${role.name}」を作成しました！（保存ボタンで確定）` });
     // Mark as unsaved so the manifest can be persisted with the new role
     setHasUnsaved(true);
     setSaveState("idle");
@@ -290,8 +294,9 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
   const uncategorizedRoles = filteredRoles.filter((r) => !r.category_id || !categoryIds.has(r.category_id));
 
   // Determine the highest position of the bot role to prevent editing roles above it
-  const botRole = allRoles.find((r) => r.name.toLowerCase() === "bot");
+  const botRole = allRoles.find((r) => r.is_our_bot);
   const botPosition = botRole ? botRole.position : undefined;
+  const botPermissions = botRole ? BigInt(botRole.permissions) : 0n;
 
   return (
     <div className={styles.page}>
@@ -325,11 +330,11 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
         </div>
         <SyncButton onSuccess={handleSyncSuccess} onError={handleSyncError} />
         <PushButton onSuccess={handlePushSuccess} onError={handlePushError} />
-        <button type="button" className={styles.btnPrimary} onClick={() => setShowNewRole(true)}>
+        <button type="button" className={styles.btnCreate} onClick={() => setShowNewRole(true)}>
           + ロール作成
         </button>
         <button type="button" className={isSelectMode ? styles.btnDanger : styles.btnSecondary} onClick={toggleSelectMode}>
-          {isSelectMode ? "キャンセル" : "⊙ カテゴリ作成"}
+          {isSelectMode ? "戻る" : "⊙ カテゴリ作成"}
         </button>
       </div>
 
@@ -416,36 +421,32 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
           );
         })}
 
-        {/* ===== Uncategorized / All roles ===== */}
-        {(uncategorizedRoles.length > 0 || localCategories.length === 0) && (
-          <div className={styles.group}>
-            <div
-              className={styles.groupHeader}
-              onClick={() => toggleCollapse("__uncategorized__")}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") toggleCollapse("__uncategorized__"); }}
-            >
-              <ChevronIcon open={!collapsedIds.has("__uncategorized__")} />
-              <span className={styles.groupName}>
-                {localCategories.length === 0 ? "ロール一覧" : "カテゴリ未設定"}
-              </span>
-              <span className={styles.groupCount}>{uncategorizedRoles.length}</span>
-            </div>
-            {!collapsedIds.has("__uncategorized__") && (
-              <RoleList
-                roles={uncategorizedRoles}
-                showHeader={false}
-                selectedIds={isSelectMode ? selectedRoleIds : undefined}
-                onToggleSelect={isSelectMode ? toggleSelectRole : undefined}
-                onReorder={!isSelectMode ? reorderGroup : undefined}
-                onPermissions={!isSelectMode ? openRolePermissions : undefined}
-                onDelete={!isSelectMode ? deleteRole : undefined}
-                botPosition={botPosition}
-              />
-            )}
+        {/* ===== Master All Roles ===== */}
+        <div className={styles.group}>
+          <div
+            className={styles.groupHeader}
+            onClick={() => toggleCollapse("__all_roles__")}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") toggleCollapse("__all_roles__"); }}
+          >
+            <ChevronIcon open={!collapsedIds.has("__all_roles__")} />
+            <span className={styles.groupName}>ロール一覧</span>
+            <span className={styles.groupCount}>{filteredRoles.length}</span>
           </div>
-        )}
+          {!collapsedIds.has("__all_roles__") && (
+            <RoleList
+              roles={filteredRoles}
+              showHeader={false}
+              selectedIds={isSelectMode ? selectedRoleIds : undefined}
+              onToggleSelect={isSelectMode ? toggleSelectRole : undefined}
+              onReorder={!isSelectMode ? reorderGroup : undefined}
+              onPermissions={!isSelectMode ? openRolePermissions : undefined}
+              onDelete={!isSelectMode ? deleteRole : undefined}
+              botPosition={botPosition}
+            />
+          )}
+        </div>
       </div>
 
       {/* Floating save bar */}
@@ -467,6 +468,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       {permTarget && (
         <PermissionEditorPanel
           target={permTarget}
+          botPermissions={botPermissions}
           onSave={handlePermissionSave}
           onClose={() => setPermTarget(null)}
         />
@@ -476,6 +478,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       {showNewRole && (
         <NewRoleModal
           categories={localCategories}
+          botPermissions={botPermissions}
           onCreated={handleRoleCreated}
           onClose={() => setShowNewRole(false)}
         />

--- a/frontend/src/components/roles/RoleList.tsx
+++ b/frontend/src/components/roles/RoleList.tsx
@@ -120,7 +120,8 @@ function SortableRoleRow({
             type="button"
             className={styles.dragHandle}
             aria-label={`${role.name} 並び替え`}
-            disabled={!enableDrag}
+            disabled={!enableDrag || isDisabled}
+            style={isDisabled ? { cursor: 'not-allowed' } : {}}
             {...attributes}
             {...listeners}
           >
@@ -155,11 +156,11 @@ function SortableRoleRow({
         {onPermissions && !onToggle && (
           <button
             type="button"
-            className={styles.permBtn}
-            onClick={onPermissions}
+            className={`${styles.permBtn} ${isDisabled ? styles.disabledBtn : ""}`}
+            onClick={isDisabled ? undefined : onPermissions}
+            aria-disabled={isDisabled}
             aria-label={`${role.name} の権限設定`}
-            title="権限設定"
-            disabled={isDisabled}
+            title={isDisabled ? "Botより上の権限は編集できません" : "権限設定"}
           >
             <ShieldIcon />
             権限

--- a/frontend/src/components/roles/SyncButton.tsx
+++ b/frontend/src/components/roles/SyncButton.tsx
@@ -38,7 +38,7 @@ export default function SyncButton({ onSuccess, onError }: Props) {
       type="button"
       onClick={handleSync}
       disabled={isPending}
-      className={styles.btnSecondary}
+      className={styles.btnSync}
     >
       {isPending ? (
         <>

--- a/frontend/src/components/roles/newrole.module.css
+++ b/frontend/src/components/roles/newrole.module.css
@@ -451,3 +451,15 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.disabledRow {
+  opacity: 0.5;
+}
+
+.botLacksMsg {
+  font-size: 10px;
+  color: #e11d48;
+  margin-left: 6px;
+  font-weight: 600;
+  vertical-align: middle;
+}

--- a/frontend/src/components/roles/permission.module.css
+++ b/frontend/src/components/roles/permission.module.css
@@ -310,3 +310,15 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.disabledRow {
+  opacity: 0.5;
+}
+
+.botLacksMsg {
+  font-size: 10px;
+  color: #e11d48;
+  margin-left: 6px;
+  font-weight: 600;
+  vertical-align: middle;
+}

--- a/frontend/src/components/roles/roles.module.css
+++ b/frontend/src/components/roles/roles.module.css
@@ -124,6 +124,47 @@
   cursor: not-allowed;
 }
 
+/* Distinct Action Buttons */
+.btnSync {
+  height: 36px;
+  padding: 0 16px;
+  border-radius: 8px;
+  background: #475569;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.btnSync:hover:not(:disabled) {
+  background: #334155;
+}
+
+.btnCreate {
+  height: 36px;
+  padding: 0 16px;
+  border-radius: 8px;
+  background: #10b981;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.btnCreate:hover:not(:disabled) {
+  background: #059669;
+}
+
 .btnDanger {
   height: 36px;
   padding: 0 16px;
@@ -369,6 +410,20 @@
   background: #e5edff;
 }
 
+.roleRow.disabledRow {
+  background: #f8fafc;
+  color: #94a3b8;
+  /* Visual gray out */
+}
+
+.roleRow.disabledRow .roleName {
+  color: #94a3b8;
+}
+
+.roleRow.disabledRow .roleDot {
+  opacity: 0.3;
+}
+
 /* Handle/checkbox cell — first grid column */
 .roleHandleCell {
   display: flex;
@@ -517,10 +572,17 @@
   white-space: nowrap;
 }
 
-.permBtn:hover {
+.permBtn:hover:not(.disabledBtn) {
   background: #eef2ff;
   border-color: #a5b4fc;
   color: #3730a3;
+}
+
+.permBtn.disabledBtn {
+  cursor: not-allowed;
+  background: transparent;
+  border-color: #e2e8f0;
+  color: #cbd5e1;
 }
 
 /* Category header permissions button */


### PR DESCRIPTION
**バックエンド**
* RoleマニフェストモデルおよびDBに `is_our_bot` を追加し（ALTER TABLE）、SELECT / INSERT / UPSERT のロジックに含める。
* `replace_roles_from_discord` を改善し、条件付きDELETE（空の場合は保持）、ロールのUPSERT、および `is_our_bot` の永続化を行う。
* `fetch_guild_roles`: ボットユーザー（@me）を取得して、どのロールがボットのものか（`tags.bot_id`）を判別し、ロールに `is_our_bot` のフラグ（注釈）を付ける。
* `push_roles_to_discord`: エラーを収集して返すようにし、作成・更新・削除・並べ替え（reorder）の操作が失敗した際に例外をログに記録する。また、並べ替えを実行する前に決定論的なポジションのペイロード（連番のポジション）を構築する。

**フロントエンド**
* 管理画面の削除されたSync / Pushグループを非表示にし、ページのボタンを整理・合理化する。
* UI側でボットの特定の権限不足を検知できるように、各ロールコンポーネントに `botPermissions`（および `botPosition`）を渡す。
* `NewRoleModal` および `PermissionEditor`: ボットの権限不足の警告を表示する。ボットに必要な権限がない場合はトグルを無効化し、ボット自身のロールより上位の権限を編集できないようにする。
* `RoleAccordion`: すべてのロールを単一のマスターリストとして扱う。`is_our_bot` を使用してボットのロールを特定し、`botPosition` を使用してボットより上位のロールの編集を防ぐ。また、作成フローとナビゲーションメッセージを更新し、Sync / Push 実行後にクエリパラメータ経由でステータス画面へリダイレクトさせる。
* `PushButton` / `SyncButton`: バックエンドからのエラーを伝播させて表示する。アクションボタンがより分かりやすくなるようにスタイルとクラス名を調整する。
* `RoleList` / `RoleRow`: 編集が許可されていない場合、ドラッグ操作と権限（perm）ボタンを無効化し、行のスタイルを変更する。
* 無効化された行、ボット権限不足メッセージ、および新しいアクションボタンのスタイルのためのCSSクラスを追加する。