### PR TITLE
fix: ロール順の同期処理、権限不足処理

### DIFF
--- a/backend/app/api/v1/roles.py
+++ b/backend/app/api/v1/roles.py
@@ -74,6 +74,7 @@ async def push_roles_to_discord(_principal: dict = Depends(require_admin)) -> di
 	deleted = 0
 	skipped_managed = 0
 	errors = []
+	created_real_ids: set[str] = set()  # track real Discord IDs for newly created roles
 
 	for role in desired_roles:
 		role_id = role["role_id"]
@@ -82,14 +83,15 @@ async def push_roles_to_discord(_principal: dict = Depends(require_admin)) -> di
 			try:
 				new_role_discord = await create_guild_role(DISCORD_GUILD_ID, token, build_role_create_payload(role))
 				created += 1
+				real_id = new_role_discord["role_id"]
 				# Replace temporary draft ID with the real Discord ID in the local DB
 				if str(role_id).startswith("draft-"):
-					real_id = new_role_discord["role_id"]
 					await asyncio.to_thread(update_role_id, role_id, real_id)
 					# Update our local mapping so the real role isn't accidentally deleted below
 					desired_by_id[real_id] = role
 					role["role_id"] = real_id
 					actual_by_id[real_id] = new_role_discord
+					created_real_ids.add(real_id)
 			except Exception as exc:
 				msg = f"Failed to create role locally {role_id}: {exc}"
 				print(msg)
@@ -125,12 +127,18 @@ async def push_roles_to_discord(_principal: dict = Depends(require_admin)) -> di
 			print(msg)
 			errors.append(msg)
 
+	# Build position payload: sort all desired roles by their position value (ascending = lower priority).
+	# Assign contiguous 1..N positions so Discord gets a clean, gapless ordering.
+	# Include roles that were just created (created_real_ids) since their real IDs are now in actual_by_id.
 	desired_roles_sorted = sorted(desired_roles, key=lambda x: int(x.get("position", 0)))
 	position_payload = []
 	current_pos = 1
 	for role in desired_roles_sorted:
-		if role["role_id"] in actual_by_id and role["role_id"] != DISCORD_GUILD_ID:
-			position_payload.append({"id": role["role_id"], "position": current_pos})
+		rid = role["role_id"]
+		if rid == DISCORD_GUILD_ID:
+			continue
+		if rid in actual_by_id or rid in created_real_ids:
+			position_payload.append({"id": rid, "position": current_pos})
 			current_pos += 1
 	reordered = 0
 	if position_payload:

--- a/backend/app/db/repository.py
+++ b/backend/app/db/repository.py
@@ -27,8 +27,15 @@ def init_db() -> None:
                         id TEXT PRIMARY KEY,
                         name TEXT NOT NULL,
                         display_order INTEGER DEFAULT 0,
-                        is_collapsed BOOLEAN DEFAULT FALSE
+                        is_collapsed BOOLEAN DEFAULT FALSE,
+                        permissions BIGINT DEFAULT 0
                     );
+                    """
+                )
+                # Migration: add permissions column if it was created without it
+                cur.execute(
+                    """
+                    ALTER TABLE role_categories ADD COLUMN IF NOT EXISTS permissions BIGINT DEFAULT 0;
                     """
                 )
                 cur.execute(
@@ -128,7 +135,7 @@ def fetch_manifest() -> dict[str, list[dict[str, Any]]]:
 		with conn.cursor() as cur:
 			cur.execute(
 				"""
-				SELECT id, name, display_order, is_collapsed
+				SELECT id, name, display_order, is_collapsed, COALESCE(permissions, 0)
 				FROM role_categories
 				ORDER BY display_order ASC, name ASC
 				"""
@@ -139,6 +146,7 @@ def fetch_manifest() -> dict[str, list[dict[str, Any]]]:
 					"name": row[1],
 					"display_order": row[2],
 					"is_collapsed": row[3],
+					"permissions": int(row[4]),
 				}
 				for row in cur.fetchall()
 			]

--- a/frontend/src/components/roles/RoleAccordion.tsx
+++ b/frontend/src/components/roles/RoleAccordion.tsx
@@ -207,10 +207,11 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
   function deleteCategory(catId: string) {
     const nextCats = localCategories.filter((c) => c.id !== catId);
     setLocalCategories(nextCats);
-    setAllRoles((prev) => prev.filter((r) => r.category_id !== catId));
+    // Uncategorize roles (don't delete them)
+    setAllRoles((prev) => prev.map((r) => r.category_id === catId ? { ...r, category_id: null } : r));
     setHasUnsaved(true);
     setSaveState("idle");
-    showStatus({ kind: "info", msg: "カテゴリとそれに含まれるロールを削除しました（保存ボタンで確定）" });
+    showStatus({ kind: "info", msg: "カテゴリを削除しました。属していたロールは「未分類」に移動しました（保存ボタンで確定）" });
   }
 
   function deleteRole(roleId: string) {
@@ -295,7 +296,20 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     hoist: boolean; mentionable: boolean; permissions: number;
     position: number; category_id: string | null; is_our_bot?: boolean;
   }) {
-    setAllRoles((prev) => [...prev, role]);
+    // Assign the new role a position that places it at the bottom of editable roles.
+    // Editable roles are those below botPosition (or all roles if no bot found).
+    // Discord positions: higher number = higher in hierarchy. 0 = @everyone.
+    // We want lowest editable position = 1 (just above @everyone).
+    const editableRoles = botPosition !== undefined
+      ? allRoles.filter((r) => r.position < botPosition)
+      : allRoles;
+    const lowestEditablePos = editableRoles.length > 0
+      ? Math.min(...editableRoles.map((r) => r.position))
+      : 1;
+    // Place new role one below the current minimum to put it at the bottom
+    const newPos = Math.max(1, lowestEditablePos - 1);
+    const roleWithPos = { ...role, position: newPos };
+    setAllRoles((prev) => [...prev, roleWithPos]);
     setShowNewRole(false);
     showStatus({ kind: "success", msg: `ロール「${role.name}」を作成しました！（保存ボタンで確定）` });
     // Mark as unsaved so the manifest can be persisted with the new role
@@ -306,8 +320,8 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
   const categoryIds = new Set(localCategories.map((c) => c.id));
   const uncategorizedRoles = filteredRoles.filter((r) => !r.category_id || !categoryIds.has(r.category_id));
 
-  // Determine the highest position of the bot role to prevent editing roles above it
-  const botRole = allRoles.find((r) => r.is_our_bot);
+  // Determine the bot role: prefer is_our_bot flag, fall back to name 'bot' as a safety net
+  const botRole = allRoles.find((r) => r.is_our_bot) ?? allRoles.find((r) => r.name.toLowerCase() === "bot");
   const botPosition = botRole ? botRole.position : undefined;
   const botPermissions = botRole ? BigInt(botRole.permissions) : 0n;
 

--- a/frontend/src/components/roles/RoleList.tsx
+++ b/frontend/src/components/roles/RoleList.tsx
@@ -99,14 +99,16 @@ function SortableRoleRow({
   const dotColor =
     !role.color || role.color === "#000000" ? "#d1d5db" : role.color;
 
-  // Detect if role has Administrator (bit 3) set
-  const isAdmin = Boolean(BigInt(role.permissions) & (1n << 3n));
-
   return (
     <div
       ref={setNodeRef}
-      style={style}
+      style={{
+        ...style,
+        cursor: isDisabled ? 'not-allowed' : undefined,
+        opacity: isDisabled ? 0.5 : 1,
+      }}
       className={`${styles.roleRow} ${isSelected ? styles.selected : ""} ${isDisabled ? styles.disabledRow : ""}`}
+      title={isDisabled ? "Botロール以上は編集できません" : undefined}
     >
       {/* Col 1: handle or checkbox */}
       <div className={styles.roleHandleCell}>
@@ -117,6 +119,7 @@ function SortableRoleRow({
             checked={isSelected}
             onChange={onToggle}
             aria-label={`${role.name} を選択`}
+            disabled={isDisabled}
           />
         ) : (
           <button
@@ -124,61 +127,44 @@ function SortableRoleRow({
             className={styles.dragHandle}
             aria-label={`${role.name} 並び替え`}
             disabled={!enableDrag || isDisabled}
-            style={isDisabled ? { cursor: 'not-allowed' } : {}}
+            style={{ cursor: isDisabled ? 'not-allowed' : 'grab' }}
             {...attributes}
-            {...listeners}
+            {...(isDisabled ? {} : listeners)}
           >
             <DragIcon />
           </button>
         )}
       </div>
 
-      {/* Col 2: dot + name + admin badge */}
-      <div className={styles.roleNameWrap}>
+      {/* Col 2: dot + name */}
+      <div className={styles.roleNameWrap} style={{ cursor: isDisabled ? 'not-allowed' : undefined }}>
         <span className={styles.roleDot} style={{ backgroundColor: dotColor }} />
         <span className={styles.roleName}>{role.name}</span>
-        {isAdmin && (
-          <span
-            style={{
-              fontSize: "10px",
-              background: "#fef3c7",
-              color: "#92400e",
-              borderRadius: "3px",
-              padding: "1px 5px",
-              fontWeight: 700,
-              flexShrink: 0,
-            }}
-          >
-            ADMIN
-          </span>
-        )}
       </div>
 
-      {/* Col 3: Default Empty space if no actions */}
+      {/* Col 3: action buttons — hidden for disabled roles */}
       <div className={styles.roleActionCol} style={{ display: 'flex', gap: '8px', alignItems: 'center', justifyContent: 'flex-end', minWidth: '100px' }}>
-        {onPermissions && !onToggle && (
+        {onPermissions && !onToggle && !isDisabled && (
           <button
             type="button"
-            className={`${styles.permBtn} ${isDisabled ? styles.disabledBtn : ""}`}
-            onClick={isDisabled ? undefined : onPermissions}
-            aria-disabled={isDisabled}
+            className={styles.permBtn}
+            onClick={onPermissions}
             aria-label={`${role.name} の権限設定`}
-            title={isDisabled ? "Botより上の権限は編集できません" : "権限設定"}
+            title="権限設定"
           >
             <ShieldIcon />
             権限
           </button>
         )}
         
-        {onDelete && !onToggle && (
+        {onDelete && !onToggle && !isDisabled && (
           <button
             type="button"
             className={styles.roleDeleteBtn}
             onClick={onDelete}
             aria-label={`${role.name} を削除`}
             title="ロールを削除"
-            disabled={isDisabled}
-            style={{ background: 'none', border: 'none', color: isDisabled ? '#9ca3af' : '#ef4444', cursor: isDisabled ? 'not-allowed' : 'pointer', fontSize: '14px', padding: '4px' }}
+            style={{ background: 'none', border: 'none', color: '#ef4444', cursor: 'pointer', fontSize: '14px', padding: '4px' }}
           >
             ✕
           </button>


### PR DESCRIPTION
### 1. ロール一覧の順番同期

**`RoleAccordion.tsx` - `handleRoleCreated` 修正**
- 新規ロール作成時に `position: 0` (固定) を割り当てていたのを改め、**Botロール未満の中で最も低いposition - 1** を自動計算して割り当てるように変更。
- これにより、新規ロールは「ロール一覧」の最下部に表示されます。

### 2. 新規ロールの1回の送信でのDiscord反映

**`backend/app/api/v1/roles.py` - `push_roles_to_discord` 修正**
- 新規作成ロール（draft-XXX → 実ID）をトラッキングする `created_real_ids` セットを追加。
- `reorder_guild_roles` のposition_payloadに、`actual_by_id OR created_real_ids` に入っているIDを使うように変更。
- これにより、**初回Push1回でロールの作成と順番が同時にDiscordに反映**されます。

### 3. botロール以上の編集ロック（刷新）

**`RoleList.tsx` 修正**
- `isDisabled`（= `position >= botPosition`）のロールに対して：
  - **行全体が半透明 (opacity: 0.5) + `cursor: not-allowed`** に
  - **ホバー時に `title` で「Botロール以上は編集できません」** と表示
  - **「権限」ボタンと「削除」ボタンは完全に非表示**に（disabled扱いではなくレンダリング自体しない）
  - **ドラッグハンドルも無効化** + `cursor: not-allowed`

### 4. 「ADMIN」バッジの削除

**`RoleList.tsx` 修正**
- Administrator権限を持つロールに表示されていた黄色い「ADMIN」バッジを完全に削除。