### PR TITLE
feat: member権限でのroleページの挙動を実装

### DIFF
--- a/backend/app/api/v1/manifest.py
+++ b/backend/app/api/v1/manifest.py
@@ -48,8 +48,8 @@ async def get_manifest(_principal: dict = Depends(require_member)) -> Manifest:
 
 
 @router.put("/manifest", response_model=Manifest)
-async def put_manifest(payload: Manifest, _principal: dict = Depends(require_admin)) -> Manifest:
-	"""マニフェスト保存。admin のみ許可。"""
+async def put_manifest(payload: Manifest, _principal: dict = Depends(require_member)) -> Manifest:
+	"""マニフェスト保存。member / admin のみ許可。"""
 	await asyncio.to_thread(
 		save_manifest,
 		[c.model_dump() for c in payload.categories],

--- a/backend/app/api/v1/roles.py
+++ b/backend/app/api/v1/roles.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from app.core.auth import require_admin, require_member
 from app.db.repository import (
+	clear_all_role_assignments,
 	fetch_guild_members,
 	fetch_manifest,
 	fetch_role_assignments,
@@ -89,6 +90,8 @@ async def refresh_roles_from_discord(_principal: dict = Depends(require_member))
 			for role_id in m.get("role_ids", []):
 				assignments.setdefault(role_id, []).append(m["user_id"])
 		print(f"[DEBUG] Found {len(assignments)} roles with assignments. Saving to DB...")
+		# First clear ALL existing assignments so that roles with 0 members don't linger
+		await asyncio.to_thread(clear_all_role_assignments)
 		await asyncio.to_thread(save_role_assignments, assignments)
 		print(f"[DEBUG] Saved role assignments to DB")
 	except Exception as exc:
@@ -103,7 +106,7 @@ async def refresh_roles_from_discord(_principal: dict = Depends(require_member))
 
 
 @router.post("/push")
-async def push_roles_to_discord(_principal: dict = Depends(require_admin)) -> dict:
+async def push_roles_to_discord(_principal: dict = Depends(require_member)) -> dict:
 	token = _get_token()
 	if not token:
 		raise HTTPException(status_code=500, detail="DISCORD_TOKEN is not configured")
@@ -125,6 +128,7 @@ async def push_roles_to_discord(_principal: dict = Depends(require_admin)) -> di
 	skipped_managed = 0
 	errors = []
 	created_real_ids: set[str] = set()  # track real Discord IDs for newly created roles
+	deleted_role_ids: set[str] = set()  # track deleted roles to skip member sync
 
 	for role in desired_roles:
 		role_id = role["role_id"]
@@ -172,6 +176,7 @@ async def push_roles_to_discord(_principal: dict = Depends(require_admin)) -> di
 		try:
 			await delete_guild_role(DISCORD_GUILD_ID, role_id, token)
 			deleted += 1
+			deleted_role_ids.add(role_id)
 		except Exception as exc:
 			msg = f"Failed to delete role {role_id}: {exc}"
 			print(msg)
@@ -226,6 +231,25 @@ async def push_roles_to_discord(_principal: dict = Depends(require_admin)) -> di
 				except Exception as exc:
 					errors.append(f"Failed to add role {role_id} to {user_id}: {exc}")
 			for user_id in current_set - desired_set:
+				try:
+					await remove_role_from_member(DISCORD_GUILD_ID, user_id, role_id, token)
+					assigned_removes += 1
+				except Exception as exc:
+					errors.append(f"Failed to remove role {role_id} from {user_id}: {exc}")
+
+		# Also handle roles that exist in Discord but have been completely removed from desired_assignments
+		# (fetch_role_assignments only returns role_ids with at least 1 member, so 0-member roles are missing)
+		for role_id, current_users in current_by_role.items():
+			if role_id in desired_assignments:
+				continue  # already handled above
+			if role_id == DISCORD_GUILD_ID or role_id.startswith("draft-"):
+				continue
+			if role_id not in actual_by_id and role_id not in created_real_ids:
+				continue
+			if role_id in deleted_role_ids:
+				continue
+			# This role has Discord members but no desired members → remove all
+			for user_id in current_users:
 				try:
 					await remove_role_from_member(DISCORD_GUILD_ID, user_id, role_id, token)
 					assigned_removes += 1
@@ -350,6 +374,55 @@ async def sync_members_from_discord(_principal: dict = Depends(require_admin)) -
 		print(f"[ERROR] Discord sync failed: {exc}")
 		traceback.print_exc()
 		raise HTTPException(status_code=502, detail=f"Discord sync failed: {exc}") from exc
+
+
+class SelfAssignPayload(BaseModel):
+	role_id: str
+
+
+# カテゴリ名で付与を禁止するカテゴリ（バックエンド側でも確認）
+MEMBER_RESTRICTED_CATEGORY_NAMES = {"会員情報", "学部学科", "学年"}
+
+
+@router.post("/self-assign")
+async def self_assign_role(
+	payload: SelfAssignPayload,
+	_principal: dict = Depends(require_member),
+) -> dict:
+	"""memberが自分自身にロールを付与する。禁止カテゴリに属するロールは拒否。"""
+	discord_id: str | None = _principal.get("discord_id")
+	if not discord_id:
+		raise HTTPException(status_code=400, detail="Discord ID が特定できません。Discordアカウントで再ログインしてください。")
+
+	token = _get_token()
+	if not token:
+		raise HTTPException(status_code=500, detail="DISCORD_TOKEN is not configured")
+
+	# マニフェストで禁止カテゴリチェック
+	manifest = await asyncio.to_thread(fetch_manifest)
+	restricted_cat_ids = {
+		c["id"] for c in manifest.get("categories", [])
+		if c["name"] in MEMBER_RESTRICTED_CATEGORY_NAMES
+	}
+	role_info = next((r for r in manifest.get("roles", []) if r["role_id"] == payload.role_id), None)
+	if role_info and role_info.get("category_id") in restricted_cat_ids:
+		raise HTTPException(status_code=403, detail="このロールは付与できません（禁止カテゴリ）")
+
+	try:
+		await add_role_to_member(DISCORD_GUILD_ID, discord_id, payload.role_id, token)
+	except Exception as exc:
+		raise HTTPException(status_code=502, detail=f"Discord API error: {exc}") from exc
+
+	# DB のロール割り当ても更新
+	try:
+		assignments = await asyncio.to_thread(fetch_role_assignments)
+		current = set(assignments.get(payload.role_id, []))
+		current.add(discord_id)
+		await asyncio.to_thread(save_role_assignments, {payload.role_id: list(current)})
+	except Exception:
+		pass  # DB更新失敗は無視（Discord側には反映済み）
+
+	return {"ok": True, "role_id": payload.role_id, "discord_id": discord_id}
 
 
 @router.get("/lists")

--- a/backend/app/db/repository.py
+++ b/backend/app/db/repository.py
@@ -413,6 +413,13 @@ def save_role_assignments(assignments: dict[str, list[str]]) -> None:
 					)
 
 
+def clear_all_role_assignments() -> None:
+	"""role_member_assignments テーブルの全行を削除する（Discordから完全再取得する際に使用）。"""
+	with _connect() as conn:
+		with conn.cursor() as cur:
+			cur.execute("DELETE FROM role_member_assignments")
+
+
 def fetch_guild_members() -> list[dict[str, Any]]:
 	"""保存済みのギルドメンバー一覧を取得。"""
 	with _connect() as conn:

--- a/frontend/src/app/(admin)/roles/page.tsx
+++ b/frontend/src/app/(admin)/roles/page.tsx
@@ -8,20 +8,20 @@ import { redirect } from "next/navigation";
 
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
 
-async function resolveRoleFromBackend(authorization: string): Promise<string> {
+async function resolveUserInfoFromBackend(authorization: string): Promise<{ app_role: string; discord_id: string | null }> {
 	try {
 		const res = await fetch(`${BACKEND_URL}/api/v1/auth/me`, {
 			headers: { Authorization: authorization },
 			cache: "no-store",
 		});
 		if (res.ok) {
-			const data = (await res.json()) as { app_role?: string };
-			return data.app_role ?? "none";
+			const data = (await res.json()) as { app_role?: string; discord_id?: string };
+			return { app_role: data.app_role ?? "none", discord_id: data.discord_id ?? null };
 		}
 	} catch {
 		// フォールバック
 	}
-	return "none";
+	return { app_role: "none", discord_id: null };
 }
 
 type SearchParamsType = {
@@ -56,7 +56,7 @@ export default async function RolesPage({ searchParams }: RolesPageProps) {
 		redirect("/login?callbackUrl=%2Froles");
 	}
 
-	const role = await resolveRoleFromBackend(authorization);
+	const { app_role: role, discord_id: myDiscordId } = await resolveUserInfoFromBackend(authorization);
 	const isAdmin = role === "admin";
 
 	const displayName =
@@ -129,6 +129,7 @@ export default async function RolesPage({ searchParams }: RolesPageProps) {
 				categories={manifest.categories}
 				roles={manifest.roles}
 				accessRole={role}
+				myDiscordId={myDiscordId}
 			/>
 		</main>
 	);

--- a/frontend/src/app/api/roles/push/route.ts
+++ b/frontend/src/app/api/roles/push/route.ts
@@ -6,7 +6,7 @@ import { fetchBackend } from "@/lib/backendFetch";
 export async function POST() {
 	try {
 		const role = await getSessionRole();
-		if (role !== "admin") {
+		if (role !== "admin" && role !== "member") {
 			return NextResponse.json({ ok: false, detail: "Forbidden" }, { status: 403 });
 		}
 

--- a/frontend/src/app/api/roles/self-assign/route.ts
+++ b/frontend/src/app/api/roles/self-assign/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
-
 import { getBackendAuthorizationHeader, getSessionRole } from "@/lib/backendAuth";
 import { fetchBackend } from "@/lib/backendFetch";
 
-export async function PUT(request: Request) {
+export async function POST(request: Request) {
 	try {
 		const role = await getSessionRole();
-		if (role !== "admin" && role !== "member") {
+		const allowed = new Set(["member", "admin", "obog"]);
+		if (!allowed.has(role)) {
 			return NextResponse.json({ ok: false, detail: "Forbidden" }, { status: 403 });
 		}
 
@@ -16,8 +16,8 @@ export async function PUT(request: Request) {
 		}
 
 		const payload = await request.json();
-		const res = await fetchBackend("/api/v1/manifest", {
-			method: "PUT",
+		const res = await fetchBackend("/api/v1/roles/self-assign", {
+			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 				Authorization: authorization,
@@ -28,6 +28,6 @@ export async function PUT(request: Request) {
 		const body = await res.json();
 		return NextResponse.json(body, { status: res.status });
 	} catch {
-		return NextResponse.json({ ok: false, detail: "manifest proxy failed" }, { status: 502 });
+		return NextResponse.json({ ok: false, detail: "proxy failed" }, { status: 502 });
 	}
 }

--- a/frontend/src/components/roles/NewRoleModal.tsx
+++ b/frontend/src/components/roles/NewRoleModal.tsx
@@ -29,6 +29,8 @@ type Props = {
   botPermissions: bigint;
   onCreated: (role: NewRoleData) => void;
   onClose: () => void;
+  isMember?: boolean;
+  restrictedCategoryNames?: Set<string>;
 };
 
 // ===== Preset palette (Discord-like) =====
@@ -46,7 +48,7 @@ function setBit(perms: bigint, bit: bigint, value: boolean): bigint {
   return value ? perms | (1n << bit) : perms & ~(1n << bit);
 }
 
-export default function NewRoleModal({ categories, botPermissions, onCreated, onClose }: Props) {
+export default function NewRoleModal({ categories, botPermissions, onCreated, onClose, isMember = false, restrictedCategoryNames = new Set() }: Props) {
   const [name, setName] = useState("");
   const [color, setColor] = useState("#99AAB5");
   const [hexInput, setHexInput] = useState("#99AAB5");
@@ -63,6 +65,14 @@ export default function NewRoleModal({ categories, botPermissions, onCreated, on
     const cat = categories.find((c) => c.id === categoryId);
     setPerms(BigInt(cat?.permissions ?? 0));
   }, [categoryId, categories]);
+
+  // memberモード: 最初の利用可能なカテゴリを自動選択
+  useEffect(() => {
+    if (isMember && categoryId === null) {
+      const first = categories.find((c) => !restrictedCategoryNames.has(c.name));
+      if (first) setCategoryId(first.id);
+    }
+  }, [isMember, categories, restrictedCategoryNames, categoryId]);
 
   function handleColorPick(c: string) {
     setColor(c);
@@ -87,6 +97,11 @@ export default function NewRoleModal({ categories, botPermissions, onCreated, on
   async function handleCreate() {
     if (!name.trim()) {
       setError("ロール名を入力してください");
+      return;
+    }
+    // memberモード: カテゴリ必須チェック
+    if (isMember && !categoryId) {
+      setError("ロールを作成するカテゴリを選択してください");
       return;
     }
     setError(null);
@@ -159,16 +174,23 @@ export default function NewRoleModal({ categories, botPermissions, onCreated, on
               />
 
               {/* Category */}
-              <label className={styles.fieldLabel}>カテゴリ</label>
+              <label className={styles.fieldLabel}>カテゴリ{isMember && <span className={styles.required}> *</span>}</label>
+              {isMember && (
+                <p style={{ fontSize: 12, color: '#6b7280', marginBottom: 4 }}>
+                  禁止カテゴリ（会員情報・学部学科・学年）およびカテゴリに属さない状態での作成できません
+                </p>
+              )}
               <select
                 className={styles.select}
                 value={categoryId ?? ""}
                 onChange={(e) => setCategoryId(e.target.value || null)}
               >
-                <option value="">カテゴリなし</option>
-                {categories.map((c) => (
-                  <option key={c.id} value={c.id}>{c.name}</option>
-                ))}
+                {!isMember && <option value="">カテゴリなし</option>}
+                {categories
+                  .filter((c) => !restrictedCategoryNames.has(c.name))
+                  .map((c) => (
+                    <option key={c.id} value={c.id}>{c.name}</option>
+                  ))}
               </select>
 
               {/* Color palette */}

--- a/frontend/src/components/roles/RoleAccordion.tsx
+++ b/frontend/src/components/roles/RoleAccordion.tsx
@@ -3,6 +3,23 @@
 "use client";
 
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import RoleList from "./RoleList";
 import SyncButton from "./SyncButton";
 import PushButton from "./PushButton";
@@ -36,6 +53,7 @@ type Props = {
   categories: Category[];
   roles: Role[];
   accessRole: string;
+  myDiscordId?: string | null;
 };
 
 type Status = {
@@ -61,9 +79,136 @@ function ShieldIcon() {
   );
 }
 
+// ===== SortableCategoryItem (DnD per category) =====
+
+type SortableCategoryItemProps = {
+  cat: Category;
+  catRoles: Role[];
+  isOpen: boolean;
+  isRestrictedCat: boolean;
+  memberCanManageCat: boolean;
+  isAdmin: boolean;
+  isMember: boolean;
+  isSelectMode: boolean;
+  selectedRoleIds: Set<string>;
+  botPosition: number | undefined;
+  onToggleCollapse: (id: string) => void;
+  onOpenCategoryPermissions: (cat: Category) => void;
+  onDeleteCategory: (id: string) => void;
+  onToggleSelect: (id: string) => void;
+  onReorder: ((ids: string[]) => void) | undefined;
+  onOpenRolePermissions: ((role: Role) => void) | undefined;
+  onDeleteRole: ((id: string) => void) | undefined;
+  onOpenMemberModal: ((role: Role) => void) | undefined;
+  styles: Record<string, string>;
+};
+
+function SortableCategoryItem({
+  cat, catRoles, isOpen, isRestrictedCat, memberCanManageCat,
+  isAdmin, isMember, isSelectMode, selectedRoleIds, botPosition,
+  onToggleCollapse, onOpenCategoryPermissions, onDeleteCategory,
+  onToggleSelect, onReorder, onOpenRolePermissions, onDeleteRole,
+  onOpenMemberModal, styles,
+}: SortableCategoryItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: cat.id });
+  const catStyle = {
+    // scaleX/scaleYを1に固定してドラッグ時の引き伸ばしを防ぐ
+    transform: CSS.Transform.toString(transform ? { ...transform, scaleX: 1, scaleY: 1 } : null),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={catStyle} className={styles.group}>
+      <div
+        className={styles.groupHeader}
+        onClick={() => onToggleCollapse(cat.id)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onToggleCollapse(cat.id); }}
+      >
+        <ChevronIcon open={isOpen} />
+        {/* Drag handle */}
+        {(isAdmin || isMember) && (
+          <span
+            {...attributes}
+            {...listeners}
+            className={styles.dragHandle}
+            title="ドラッグでカテゴリを並び替え"
+            onClick={(e) => e.stopPropagation()}
+            style={{ cursor: isDragging ? "grabbing" : "grab", padding: "0 4px", lineHeight: 1 }}
+          >
+            ⠿
+          </span>
+        )}
+        <span className={styles.groupName}>{cat.name}</span>
+        <span className={styles.groupCount}>{catRoles.length}</span>
+
+        {isAdmin ? (
+          <button
+            type="button"
+            className={styles.catPermBtn}
+            onClick={(e) => { e.stopPropagation(); onOpenCategoryPermissions(cat); }}
+            title="カテゴリ権限設定"
+            aria-label={`${cat.name} の権限設定`}
+          >
+            <ShieldIcon />
+            権限
+          </button>
+        ) : null}
+
+        {/* member: ロールが残っている場合は削除不可。admin: 制限なし */}
+        {isAdmin ? (
+          <button
+            type="button"
+            className={styles.groupDeleteBtn}
+            onClick={(e) => { e.stopPropagation(); onDeleteCategory(cat.id); }}
+            aria-label={`${cat.name} を削除`}
+            title="カテゴリを削除"
+          >
+            ✕
+          </button>
+        ) : memberCanManageCat ? (
+          <button
+            type="button"
+            className={`${styles.groupDeleteBtn} ${catRoles.length > 0 ? styles.btnDisabled ?? "" : ""}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (catRoles.length > 0) return;
+              onDeleteCategory(cat.id);
+            }}
+            disabled={catRoles.length > 0}
+            aria-label={`${cat.name} を削除`}
+            title={catRoles.length > 0
+              ? `カテゴリ内のロール（${catRoles.length}件）をすべて削除してからカテゴリを削除できます`
+              : "カテゴリを削除"
+            }
+          >
+            ✕
+          </button>
+        ) : null}
+      </div>
+
+      {isOpen && (
+        <RoleList
+          roles={catRoles}
+          showHeader={false}
+          selectedIds={isSelectMode ? selectedRoleIds : undefined}
+          onToggleSelect={isSelectMode ? onToggleSelect : undefined}
+          onReorder={!isSelectMode && isAdmin ? onReorder : undefined}
+          onPermissions={!isSelectMode && isAdmin ? onOpenRolePermissions : undefined}
+          onDelete={!isSelectMode && (isAdmin || memberCanManageCat) ? onDeleteRole : undefined}
+          onMembers={!isSelectMode && (isAdmin || memberCanManageCat) ? onOpenMemberModal : undefined}
+          botPosition={botPosition}
+        />
+      )}
+    </div>
+  );
+}
+
 // ===== Component =====
 
-export default function RoleAccordion({ categories: initCategories, roles: initRoles, accessRole }: Props) {
+export default function RoleAccordion({ categories: initCategories, roles: initRoles, accessRole, myDiscordId = null }: Props) {
   const [query, setQuery] = useState("");
   const [allRoles, setAllRoles] = useState<Role[]>([]);
   const [localCategories, setLocalCategories] = useState<Category[]>([]);
@@ -90,11 +235,17 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
   const [allMembers, setAllMembers] = useState<Member[]>([]);
   const [membersByRole, setMembersByRole] = useState<Record<string, string[]>>({});
   const [memberModalRole, setMemberModalRole] = useState<Role | null>(null);
+  const [memberModalReadOnly, setMemberModalReadOnly] = useState(false);
 
   const isAdmin = accessRole === "admin";
+  const isMember = accessRole === "member";
   const canCreateRole = ["admin", "member", "obog"].includes(accessRole);
+  const canCreateCategory = isAdmin || isMember;
   const canManageMembers = isAdmin;
-  const canEditManifest = isAdmin;
+  const canEditManifest = isAdmin || isMember;
+
+  // memberモードでロール付与を禁止するカテゴリ名
+  const RESTRICTED_CATEGORY_NAMES = new Set(["\u4f1a\u54e1\u60c5\u5831", "\u5b66\u90e8\u5b66\u79d1", "\u5b66\u5e74"]);
 
   function showStatus(s: Status, durationMs = 5000) {
     setStatus(s);
@@ -138,13 +289,14 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     return allRoles.filter((r) => r.name.toLowerCase().includes(normalizedQuery));
   }, [allRoles, normalizedQuery]);
 
+  // DnD sensors for category reorder
+  const useCatDndSensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
   // ===== Persist =====
   async function persistRoles(nextRoles: Role[], nextCats: Category[]) {
-    if (!canEditManifest) {
-      showStatus({ kind: "error", msg: "member 権限では保存できません（モック表示）" });
-      return;
-    }
-
     setSaveState("saving");
     try {
       const res = await fetch("/api/manifest", {
@@ -212,7 +364,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
 
   function createCategory() {
     const name = newCategoryName.trim();
-    if (!name || selectedRoleIds.size === 0) return;
+    if (!name) return;
     const newCatId = `cat_${Date.now()}`;
     const newCat: Category = { id: newCatId, name, display_order: localCategories.length, is_collapsed: false, permissions: 0 };
     const updatedRoles = allRoles.map((r) => selectedRoleIds.has(r.role_id) ? { ...r, category_id: newCatId } : r);
@@ -242,6 +394,16 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     setHasUnsaved(true);
     setSaveState("idle");
     showStatus({ kind: "info", msg: "ロールを削除しました（保存ボタンで確定）" });
+  }
+
+  // カテゴリの並び替え（DnD完了時）
+  function reorderCategories(oldIndex: number, newIndex: number) {
+    setLocalCategories((prev) => {
+      const next = arrayMove(prev, oldIndex, newIndex);
+      return next.map((c, i) => ({ ...c, display_order: i }));
+    });
+    setHasUnsaved(true);
+    setSaveState("idle");
   }
 
   // ===== SyncButton / PushButton =====
@@ -343,6 +505,13 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
 
   // ===== Member management callbacks =====
   const handleOpenMemberModal = useCallback((role: Role) => {
+    setMemberModalReadOnly(false);
+    setMemberModalRole(role);
+  }, []);
+
+  // ロール一覧用: 閉覧のみで開く
+  const handleOpenMemberModalReadOnly = useCallback((role: Role) => {
+    setMemberModalReadOnly(true);
     setMemberModalRole(role);
   }, []);
 
@@ -359,6 +528,31 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     const detail = `付与 ${add.length}名 / 削除 ${remove.length}名`;
     showStatus({ kind: "success", msg: `メンバー割り当てを変更しました（${detail}）（保存ボタンで確定）` });
   }
+
+  // ===== Self-assign (member mode) =====
+  const handleSelfAssign = useCallback(async (role: Role) => {
+    // 禁止カテゴリチェック
+    const cat = localCategories.find((c) => c.id === role.category_id);
+    if (cat && RESTRICTED_CATEGORY_NAMES.has(cat.name)) {
+      showStatus({ kind: "error", msg: `「${cat.name}」カテゴリのロールは付与できません` });
+      return;
+    }
+    try {
+      const res = await fetch("/api/roles/self-assign", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role_id: role.role_id }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        showStatus({ kind: "error", msg: data.detail ?? "ロールの付与に失敗しました" });
+        return;
+      }
+      showStatus({ kind: "success", msg: `ロール「${role.name}」を自分に付与しました` });
+    } catch {
+      showStatus({ kind: "error", msg: "ロールの付与に失敗しました。接続を確認してください" });
+    }
+  }, [localCategories, RESTRICTED_CATEGORY_NAMES]);
 
   const categoryIds = new Set(localCategories.map((c) => c.id));
   const uncategorizedRoles = filteredRoles.filter((r) => !r.category_id || !categoryIds.has(r.category_id));
@@ -399,7 +593,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
           />
         </div>
         <SyncButton onSuccess={handleSyncSuccess} onError={handleSyncError} />
-        {isAdmin ? <PushButton onSuccess={handlePushSuccess} onError={handlePushError} /> : null}
+        {(isAdmin || isMember) ? <PushButton onSuccess={handlePushSuccess} onError={handlePushError} /> : null}
         {canCreateRole ? (
           <button type="button" className={styles.btnCreate} onClick={() => setShowNewRole(true)}>
             + ロール作成
@@ -409,8 +603,8 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
           type="button"
           className={isSelectMode ? styles.btnDanger : styles.btnSecondary}
           onClick={toggleSelectMode}
-          disabled={!isAdmin}
-          title={isAdmin ? "カテゴリ作成" : "カテゴリ作成は admin のみ可能"}
+          disabled={!canCreateCategory}
+          title={canCreateCategory ? "カテゴリ作成" : "カテゴリ作成は admin/member のみ可能"}
         >
           {isSelectMode ? "戻る" : "⊙ カテゴリ作成"}
         </button>
@@ -419,7 +613,9 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       <div className={`${styles.statusBanner} ${styles.info}`}>
         {isAdmin
           ? "adminモード: すべての管理操作が有効です。"
-          : "memberモード: admin専用操作（カテゴリ作成・権限編集・並び替え・会員管理）は無効です。"}
+          : isMember
+          ? "memberモード: ロール・カテゴリの作成および自分へのロール付与ができます。会員全体のロール管理は無効です。"
+          : "obogモード: ロール作成のみ可能です。"}
       </div>
 
       {/* Category creation selection bar */}
@@ -437,7 +633,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
             onKeyDown={(e) => { if (e.key === "Enter") createCategory(); }}
           />
           <button type="button" className={styles.btnPrimary} onClick={createCategory}
-            disabled={!newCategoryName.trim() || selectedRoleIds.size === 0}>
+            disabled={!newCategoryName.trim()}>
             作成
           </button>
         </div>
@@ -446,71 +642,51 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       {/* Role board */}
       <div className={styles.board}>
 
-        {/* ===== Categorized groups ===== */}
-        {localCategories.map((cat) => {
-          const catRoles = filteredRoles.filter((r) => r.category_id === cat.id);
-          if (catRoles.length === 0 && !isSelectMode) return null;
-          const isOpen = !collapsedIds.has(cat.id);
-
-          return (
-            <div key={cat.id} className={styles.group}>
-              <div
-                className={styles.groupHeader}
-                onClick={() => toggleCollapse(cat.id)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") toggleCollapse(cat.id); }}
-              >
-                <ChevronIcon open={isOpen} />
-                <span className={styles.groupName}>{cat.name}</span>
-                <span className={styles.groupCount}>{catRoles.length}</span>
-
-                {/* Category permissions button */}
-                {isAdmin ? (
-                  <button
-                    type="button"
-                    className={styles.catPermBtn}
-                    onClick={(e) => { e.stopPropagation(); openCategoryPermissions(cat); }}
-                    title="カテゴリ権限設定"
-                    aria-label={`${cat.name} の権限設定`}
-                  >
-                    <ShieldIcon />
-                    権限
-                  </button>
-                ) : null}
-
-                {/* Delete button */}
-                {isAdmin ? (
-                  <button
-                    type="button"
-                    className={styles.groupDeleteBtn}
-                    onClick={(e) => { e.stopPropagation(); deleteCategory(cat.id); }}
-                    aria-label={`${cat.name} を削除`}
-                    title="カテゴリを削除"
-                  >
-                    ✕
-                  </button>
-                ) : null}
-              </div>
-
-              {isOpen && (
-                <RoleList
-                  roles={catRoles}
-                  showHeader={false}
-                  selectedIds={isSelectMode ? selectedRoleIds : undefined}
-                  onToggleSelect={isSelectMode ? toggleSelectRole : undefined}
-                  onReorder={!isSelectMode && isAdmin ? reorderGroup : undefined}
-                  onPermissions={!isSelectMode && isAdmin ? openRolePermissions : undefined}
-                  onDelete={!isSelectMode && isAdmin ? deleteRole : undefined}
-                  onMembers={!isSelectMode && isAdmin ? handleOpenMemberModal : undefined}
+        {/* ===== Categorized groups with DnD reordering ===== */}
+        <DndContext
+          sensors={useCatDndSensors}
+          collisionDetection={closestCenter}
+          onDragEnd={(event: DragEndEvent) => {
+            const { active, over } = event;
+            if (!over || active.id === over.id) return;
+            const oldIdx = localCategories.findIndex((c) => c.id === active.id);
+            const newIdx = localCategories.findIndex((c) => c.id === over.id);
+            if (oldIdx !== -1 && newIdx !== -1) reorderCategories(oldIdx, newIdx);
+          }}
+        >
+          <SortableContext items={localCategories.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+            {localCategories.map((cat) => {
+              const catRoles = filteredRoles.filter((r) => r.category_id === cat.id);
+              const isOpen = !collapsedIds.has(cat.id);
+              const isRestrictedCat = RESTRICTED_CATEGORY_NAMES.has(cat.name);
+              const memberCanManageCat = isMember && !isRestrictedCat;
+              return (
+                <SortableCategoryItem
+                  key={cat.id}
+                  cat={cat}
+                  catRoles={catRoles}
+                  isOpen={isOpen}
+                  isRestrictedCat={isRestrictedCat}
+                  memberCanManageCat={memberCanManageCat}
+                  isAdmin={isAdmin}
+                  isMember={isMember}
+                  isSelectMode={isSelectMode}
+                  selectedRoleIds={selectedRoleIds}
                   botPosition={botPosition}
+                  onToggleCollapse={toggleCollapse}
+                  onOpenCategoryPermissions={openCategoryPermissions}
+                  onDeleteCategory={deleteCategory}
+                  onToggleSelect={toggleSelectRole}
+                  onReorder={!isSelectMode && isAdmin ? reorderGroup : undefined}
+                  onOpenRolePermissions={!isSelectMode && isAdmin ? openRolePermissions : undefined}
+                  onDeleteRole={!isSelectMode && (isAdmin || memberCanManageCat) ? deleteRole : undefined}
+                  onOpenMemberModal={!isSelectMode && (isAdmin || memberCanManageCat) ? handleOpenMemberModal : undefined}
+                  styles={styles}
                 />
-              )}
-            </div>
-          );
-        })}
-
-
+              );
+            })}
+          </SortableContext>
+        </DndContext>
 
         {/* ===== Master All Roles ===== */}
         <div className={styles.group}>
@@ -534,7 +710,11 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
               onReorder={!isSelectMode && isAdmin ? reorderGroup : undefined}
               onPermissions={!isSelectMode && isAdmin ? openRolePermissions : undefined}
               onDelete={!isSelectMode && isAdmin ? deleteRole : undefined}
-              onMembers={!isSelectMode && isAdmin ? handleOpenMemberModal : undefined}
+              onMembers={
+                !isSelectMode && (isAdmin || isMember)
+                  ? handleOpenMemberModalReadOnly
+                  : undefined
+              }
               botPosition={botPosition}
             />
           )}
@@ -544,11 +724,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       {/* Floating save bar */}
       {hasUnsaved && (
         <div className={styles.unsavedBar}>
-          <span>
-            {canEditManifest
-              ? "未保存の変更があります"
-              : "未保存の変更があります（memberモック: 保存はadminのみ）"}
-          </span>
+          <span>未保存の変更があります</span>
           <button
             type="button"
             className={styles.unsavedBarBtn}
@@ -577,6 +753,8 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
           botPermissions={botPermissions}
           onCreated={handleRoleCreated}
           onClose={() => setShowNewRole(false)}
+          isMember={isMember}
+          restrictedCategoryNames={RESTRICTED_CATEGORY_NAMES}
         />
       )}
 
@@ -590,6 +768,8 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
           onCommit={(add, remove) => handleMemberCommit(memberModalRole.role_id, add, remove)}
           onClose={() => setMemberModalRole(null)}
           isLocked={botPosition !== undefined && memberModalRole.position >= botPosition}
+          readOnly={memberModalReadOnly}
+          selfDiscordId={(!memberModalReadOnly && isMember) ? myDiscordId : null}
         />
       )}
 

--- a/frontend/src/components/roles/RoleList.tsx
+++ b/frontend/src/components/roles/RoleList.tsx
@@ -147,7 +147,7 @@ function SortableRoleRow({
 
       {/* Col 3: action buttons */}
       <div className={styles.roleActionCol} style={{ display: 'flex', gap: '8px', alignItems: 'center', justifyContent: 'flex-end', minWidth: '160px' }}>
-        {onMembers && !onToggle && (
+        {onMembers && !onToggle && !isDisabled && (
           <button
             type="button"
             className={styles.membersBtn}

--- a/frontend/src/components/roles/RoleMemberModal.tsx
+++ b/frontend/src/components/roles/RoleMemberModal.tsx
@@ -19,8 +19,12 @@ type Props = {
   /** 現在このロールを持つメンバーのuser_idセット */
   currentMemberIds: string[];
   isLocked?: boolean;
+  /** trueの場合：閉覧のみ（付与・削除ボタン非表示） */
+  readOnly?: boolean;
   onCommit: (add: string[], remove: string[]) => void;
   onClose: () => void;
+  /** 設定時: このユーザーのみ操作可（memberモード用） */
+  selfDiscordId?: string | null;
 };
 
 type Screen = "list" | "grant" | "revoke";
@@ -46,8 +50,10 @@ export default function RoleMemberModal({
   allMembers,
   currentMemberIds,
   isLocked,
+  readOnly = false,
   onCommit,
   onClose,
+  selfDiscordId = null,
 }: Props) {
   const [screen, setScreen] = useState<Screen>("list");
   // ローカルの付与済みセット（コミットするまで反映しない）
@@ -127,17 +133,18 @@ export default function RoleMemberModal({
             {filteredAll.map((m) => {
               const alreadyHas = localMemberIds.has(m.user_id);
               const checked = selectedForGrant.has(m.user_id);
+              const isSelfOnly = selfDiscordId !== null && m.user_id !== selfDiscordId;
               return (
                 <label
                   key={m.user_id}
-                  className={`${styles.memberRow} ${alreadyHas ? styles.disabled : ""}`}
+                  className={`${styles.memberRow} ${alreadyHas || isSelfOnly ? styles.disabled : ""}`}
                 >
                   <input
                     type="checkbox"
-                    disabled={alreadyHas}
+                    disabled={alreadyHas || isSelfOnly}
                     checked={checked}
                     onChange={() => {
-                      if (alreadyHas) return;
+                      if (alreadyHas || isSelfOnly) return;
                       setSelectedForGrant((prev) => {
                         const next = new Set(prev);
                         if (next.has(m.user_id)) next.delete(m.user_id);
@@ -149,6 +156,7 @@ export default function RoleMemberModal({
                   <MemberAvatar member={m} />
                   <span className={styles.memberName}>{m.display_name || m.username}</span>
                   {alreadyHas && <span className={styles.badge}>付与済</span>}
+                  {!alreadyHas && isSelfOnly && <span className={styles.badge} style={{ background: '#6b7280' }}>操作不可</span>}
                 </label>
               );
             })}
@@ -200,12 +208,15 @@ export default function RoleMemberModal({
             )}
             {filteredCurrent.map((m) => {
               const checked = selectedForRevoke.has(m.user_id);
+              const isSelfOnly = selfDiscordId !== null && m.user_id !== selfDiscordId;
               return (
-                <label key={m.user_id} className={styles.memberRow}>
+                <label key={m.user_id} className={`${styles.memberRow} ${isSelfOnly ? styles.disabled : ""}`}>
                   <input
                     type="checkbox"
                     checked={checked}
+                    disabled={isSelfOnly}
                     onChange={() => {
+                      if (isSelfOnly) return;
                       setSelectedForRevoke((prev) => {
                         const next = new Set(prev);
                         if (next.has(m.user_id)) next.delete(m.user_id);
@@ -216,6 +227,7 @@ export default function RoleMemberModal({
                   />
                   <MemberAvatar member={m} />
                   <span className={styles.memberName}>{m.display_name || m.username}</span>
+                  {isSelfOnly && <span className={styles.badge} style={{ background: '#6b7280' }}>操作不可</span>}
                 </label>
               );
             })}
@@ -265,7 +277,7 @@ export default function RoleMemberModal({
         </div>
 
         <div className={styles.footer}>
-          {!isLocked && (
+          {!readOnly && !isLocked && (
             <div style={{ display: "flex", gap: "8px" }}>
               <button
                 type="button"
@@ -287,18 +299,23 @@ export default function RoleMemberModal({
           {isLocked && (
             <span className={styles.lockedMsg}>Botより上位のロールは編集できません</span>
           )}
+          {readOnly && (
+            <span className={styles.lockedMsg}>閲覧のみ（付与・削除は各カテゴリから行えます）</span>
+          )}
           <div style={{ display: "flex", gap: "8px" }}>
             <button type="button" className={styles.cancelBtn} onClick={onClose}>
               戻る
             </button>
-            <button
-              type="button"
-              className={`${styles.actionBtn} ${!hasChanges ? styles.dimmed : ""}`}
-              onClick={handleCommit}
-              disabled={!hasChanges}
-            >
-              変更を確定
-            </button>
+            {!readOnly && (
+              <button
+                type="button"
+                className={`${styles.actionBtn} ${!hasChanges ? styles.dimmed : ""}`}
+                onClick={handleCommit}
+                disabled={!hasChanges}
+              >
+                変更を確定
+              </button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要
これまで `admin` 用として実装されていたロール管理ページにおいて、`member` 権限でも機能を利用できるよう、適切な制限の下で実装しました。また、それに関連するUIのバグ修正やUI調整などを実装しています。

## 行った変更
### 1. member 権限に対する役割操作の権限設定
`member`権限のユーザに対する操作と保護の設定:
- 「会員情報」「学部学科」「学年」のカテゴリ（以下「特定カテゴリ」）以外のカテゴリに属するロールに対して、ロールの追加・削除
 - 特定カテゴリ内のロールに対しては操作ができず、属するメンバーの閲覧のみ可能
- カテゴリを削除する際、カテゴリ内部にロールが1つでも残っている場合は削除できない（`admin`権限のユーザの場合はそのような場合でも可能であり、どのカテゴリにも属さないロールが「ロール一覧」に残ることになる）。

### 2. UI/UX の改善
- カテゴリの並び替え機能を実装
  - `@dnd-kit` を導入し、カテゴリの表示順をドラッグ＆ドロップで任意に入れ替えられる機能を実装しました。
- 空のカテゴリを作成可能に
  - 中にロールが一つも登録されていない状態のカテゴリでも、UIから消滅することなく枠組みとして表示され続けるように修正しました。
