### PR TITLE
fix: memberログイン時のUIを変更

### DIFF
--- a/backend/app/api/v1/roles.py
+++ b/backend/app/api/v1/roles.py
@@ -489,6 +489,46 @@ async def self_assign_role(
 	return {"ok": True, "role_id": payload.role_id, "discord_id": discord_id}
 
 
+@router.post("/self-remove")
+async def self_remove_role(
+	payload: SelfAssignPayload,
+	_principal: dict = Depends(require_member),
+) -> dict:
+	"""memberが自分自身からロールを解除する。禁止カテゴリに属するロールは拒否。"""
+	discord_id: str | None = _principal.get("discord_id")
+	if not discord_id:
+		raise HTTPException(status_code=400, detail="Discord ID が特定できません。Discordアカウントで再ログインしてください。")
+
+	token = _get_token()
+	if not token:
+		raise HTTPException(status_code=500, detail="DISCORD_TOKEN is not configured")
+
+	# マニフェストで禁止カテゴリチェック
+	manifest = await asyncio.to_thread(fetch_manifest)
+	restricted_cat_ids = {
+		c["id"] for c in manifest.get("categories", [])
+		if c["name"] in MEMBER_RESTRICTED_CATEGORY_NAMES
+	}
+	role_info = next((r for r in manifest.get("roles", []) if r["role_id"] == payload.role_id), None)
+	if role_info and role_info.get("category_id") in restricted_cat_ids:
+		raise HTTPException(status_code=403, detail="このロールは解除できません（禁止カテゴリ）")
+
+	try:
+		await remove_role_from_member(DISCORD_GUILD_ID, discord_id, payload.role_id, token)
+	except Exception as exc:
+		raise HTTPException(status_code=502, detail=f"Discord API error: {exc}") from exc
+
+	# DB のロール割り当ても更新
+	try:
+		assignments = await asyncio.to_thread(fetch_role_assignments)
+		current = set(assignments.get(payload.role_id, []))
+		current.discard(discord_id)
+		await asyncio.to_thread(save_role_assignments, {payload.role_id: list(current)})
+	except Exception:
+		pass  # DB更新失敗は無視（Discord側には反映済み）
+
+	return {"ok": True, "role_id": payload.role_id, "discord_id": discord_id}
+
 @router.get("/lists")
 async def get_lists(_principal: dict = Depends(require_member)) -> dict:
 	"""member_list / admin_list / pre_member_list を取得."""

--- a/frontend/src/app/(admin)/roles/page.tsx
+++ b/frontend/src/app/(admin)/roles/page.tsx
@@ -4,6 +4,7 @@ import { createSupabaseServer } from "@/lib/supabase";
 import { getBackendAuthorizationHeader } from "@/lib/backendAuth";
 import { fetchManifest } from "@/actions/manifest";
 import RoleAccordion from "@/components/roles/RoleAccordion";
+import MemberSelfView from "@/components/roles/MemberSelfView";
 import { redirect } from "next/navigation";
 
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
@@ -57,13 +58,15 @@ export default async function RolesPage({ searchParams }: RolesPageProps) {
 	}
 
 	const { app_role: role, discord_id: myDiscordId } = await resolveUserInfoFromBackend(authorization);
-	const isAdmin = role === "admin";
+	const isMember = role === "member";
 
 	const displayName =
 		user.user_metadata?.full_name ??
 		user.user_metadata?.name ??
 		user.email ??
 		"不明";
+
+	const avatarUrl: string | null = user.user_metadata?.avatar_url ?? null;
 
 	let manifest;
 	let accessError: string | null = null;
@@ -125,12 +128,22 @@ export default async function RolesPage({ searchParams }: RolesPageProps) {
 				<p style={{ marginTop: 8, color: "#b91c1c" }}>{accessError}</p>
 			) : null}
 
-			<RoleAccordion
-				categories={manifest.categories}
-				roles={manifest.roles}
-				accessRole={role}
-				myDiscordId={myDiscordId}
-			/>
+			{isMember ? (
+				<MemberSelfView
+					categories={manifest.categories}
+					roles={manifest.roles}
+					myDiscordId={myDiscordId}
+					displayName={displayName}
+					avatarUrl={avatarUrl}
+				/>
+			) : (
+				<RoleAccordion
+					categories={manifest.categories}
+					roles={manifest.roles}
+					accessRole={role}
+					myDiscordId={myDiscordId}
+				/>
+			)}
 		</main>
 	);
 }

--- a/frontend/src/app/api/roles/self-remove/route.ts
+++ b/frontend/src/app/api/roles/self-remove/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { getBackendAuthorizationHeader, getSessionRole } from "@/lib/backendAuth";
+import { fetchBackend } from "@/lib/backendFetch";
+
+export async function POST(request: Request) {
+	try {
+		const role = await getSessionRole();
+		const allowed = new Set(["member", "admin", "obog"]);
+		if (!allowed.has(role)) {
+			return NextResponse.json({ ok: false, detail: "Forbidden" }, { status: 403 });
+		}
+
+		const authorization = await getBackendAuthorizationHeader();
+		if (!authorization) {
+			return NextResponse.json({ ok: false, detail: "Unauthorized" }, { status: 401 });
+		}
+
+		const payload = await request.json();
+		const res = await fetchBackend("/api/v1/roles/self-remove", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: authorization,
+			},
+			body: JSON.stringify(payload),
+			cache: "no-store",
+		});
+		const body = await res.json();
+		return NextResponse.json(body, { status: res.status });
+	} catch {
+		return NextResponse.json({ ok: false, detail: "proxy failed" }, { status: 502 });
+	}
+}

--- a/frontend/src/components/roles/MemberSelfView.tsx
+++ b/frontend/src/components/roles/MemberSelfView.tsx
@@ -1,0 +1,398 @@
+// 役割: Member専用ロール管理ビュー（個人単位）
+// ロール付与/解除はローカルで変更 → 保存 → Discord送信の2ステップ（admin同様）
+
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import SyncButton from "./SyncButton";
+import PushButton from "./PushButton";
+import styles from "./memberself.module.css";
+
+type Category = {
+  id: string;
+  name: string;
+  display_order: number;
+  is_collapsed: boolean;
+  permissions: number;
+};
+
+type Role = {
+  role_id: string;
+  name: string;
+  hoist: boolean;
+  mentionable: boolean;
+  permissions: number;
+  position: number;
+  color: string;
+  category_id: string | null;
+  is_our_bot?: boolean;
+};
+
+type Status = {
+  kind: "success" | "error" | "info";
+  msg: string;
+};
+
+type Props = {
+  categories: Category[];
+  roles: Role[];
+  myDiscordId: string | null;
+  displayName: string;
+  avatarUrl: string | null;
+};
+
+const RESTRICTED_CATEGORY_NAMES = new Set(["会員情報", "学部学科", "学年"]);
+
+export default function MemberSelfView({ categories, roles, myDiscordId, displayName, avatarUrl }: Props) {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [collapsedCats, setCollapsedCats] = useState<Set<string>>(new Set());
+
+  // --- Role assignment state (batch mode, like admin) ---
+  const [membersByRole, setMembersByRole] = useState<Record<string, string[]>>({});
+  const initialAssignmentsRef = useRef<Record<string, string[]>>({});
+  const [hasUnsaved, setHasUnsaved] = useState(false);
+  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+
+  // Sort roles by position descending (same as Discord hierarchy)
+  const sortedRoles = [...roles].sort((a, b) => b.position - a.position);
+
+  // Determine bot role and botPosition for hierarchy constraints
+  const botRole = roles.find((r) => r.is_our_bot) ?? roles.find((r) => r.name.toLowerCase() === "bot");
+  const botPosition = botRole ? botRole.position : undefined;
+
+  // Fetch all member assignments
+  const fetchMembers = useCallback(async () => {
+    try {
+      const res = await fetch("/api/roles/members");
+      if (res.ok) {
+        const data = await res.json();
+        if (data.assignments) {
+          setMembersByRole(data.assignments);
+          initialAssignmentsRef.current = JSON.parse(JSON.stringify(data.assignments));
+        }
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMembers();
+  }, [fetchMembers]);
+
+  function showStatus(s: Status, durationMs = 5000) {
+    setStatus(s);
+    if (durationMs > 0) {
+      setTimeout(() => setStatus(null), durationMs);
+    }
+  }
+
+  // --- Local toggle (no API call, just state change) ---
+  function toggleMyRole(roleId: string) {
+    if (!myDiscordId) return;
+    setMembersByRole((prev) => {
+      const current = new Set(prev[roleId] ?? []);
+      if (current.has(myDiscordId)) {
+        current.delete(myDiscordId);
+      } else {
+        current.add(myDiscordId);
+      }
+      return { ...prev, [roleId]: [...current] };
+    });
+    setHasUnsaved(true);
+    setSaveState("idle");
+  }
+
+  // --- Save to DB (same as admin's persistRoles) ---
+  async function handleSave() {
+    setSaveState("saving");
+    try {
+      const initAssignments = initialAssignmentsRef.current;
+      const upsertRoleAssignments: Record<string, string[]> = {};
+
+      for (const roleId of Object.keys(membersByRole)) {
+        const curr = [...membersByRole[roleId]].sort();
+        const init = [...(initAssignments[roleId] || [])].sort();
+        if (JSON.stringify(curr) !== JSON.stringify(init)) {
+          upsertRoleAssignments[roleId] = membersByRole[roleId];
+        }
+      }
+
+      const hasDiff = Object.keys(upsertRoleAssignments).length > 0;
+      if (!hasDiff) {
+        setHasUnsaved(false);
+        setSaveState("idle");
+        showStatus({ kind: "info", msg: "変更点はありませんでした" });
+        return;
+      }
+
+      const payload = {
+        upsert_categories: [],
+        delete_category_ids: [],
+        upsert_roles: [],
+        delete_role_ids: [],
+        upsert_role_assignments: upsertRoleAssignments,
+      };
+
+      const res = await fetch("/api/manifest", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        setSaveState("error");
+        showStatus({ kind: "error", msg: "保存に失敗しました。再度お試しください。" });
+        return;
+      }
+
+      setHasUnsaved(false);
+      setSaveState("saved");
+      showStatus({ kind: "success", msg: "変更を保存しました" });
+      initialAssignmentsRef.current = JSON.parse(JSON.stringify(membersByRole));
+    } catch {
+      setSaveState("error");
+      showStatus({ kind: "error", msg: "保存に失敗しました。接続を確認してください。" });
+    }
+  }
+
+  function toggleCat(catId: string) {
+    setCollapsedCats((prev) => {
+      const next = new Set(prev);
+      if (next.has(catId)) next.delete(catId);
+      else next.add(catId);
+      return next;
+    });
+  }
+
+  // --- Helpers ---
+  function isAboveBot(role: Role): boolean {
+    return botPosition !== undefined && role.position >= botPosition;
+  }
+
+  function isRestrictedCategory(role: Role): boolean {
+    if (!role.category_id) return false;
+    const cat = categories.find((c) => c.id === role.category_id);
+    return cat ? RESTRICTED_CATEGORY_NAMES.has(cat.name) : false;
+  }
+
+  function isRemoveDisabled(role: Role): boolean {
+    return isAboveBot(role) || isRestrictedCategory(role);
+  }
+
+  function hasRole(roleId: string): boolean {
+    if (!myDiscordId) return false;
+    return (membersByRole[roleId] ?? []).includes(myDiscordId);
+  }
+
+  // Sync / Push handlers
+  function handleSyncSuccess(count: number) {
+    window.location.href = `/roles?synced=1&roles=${count}&t=${Date.now()}`;
+  }
+  function handleSyncError() {
+    showStatus({ kind: "error", msg: "Discord からの取得に失敗しました" });
+  }
+  function handlePushSuccess(result: { updated?: number; created?: number; deleted?: number; reordered?: number }) {
+    window.location.href = `/roles?pushed=1&updated=${result.updated ?? 0}&created=${result.created ?? 0}&deleted=${result.deleted ?? 0}&reordered=${result.reordered ?? 0}&t=${Date.now()}`;
+  }
+  function handlePushError(errors?: string[]) {
+    showStatus({ kind: "error", msg: errors?.[0] ?? "Discord への送信に失敗しました" });
+  }
+
+  // My current roles
+  const myRoles = sortedRoles.filter((r) => hasRole(r.role_id));
+
+  // Sort categories: editable first, then restricted (会員情報→学年→学部学科)
+  const RESTRICTED_ORDER: Record<string, number> = { "会員情報": 0, "学年": 1, "学部学科": 2 };
+  const sortedCategories = [...categories].sort((a, b) => {
+    const aR = RESTRICTED_CATEGORY_NAMES.has(a.name);
+    const bR = RESTRICTED_CATEGORY_NAMES.has(b.name);
+    if (aR !== bR) return aR ? 1 : -1;
+    if (aR && bR) return (RESTRICTED_ORDER[a.name] ?? 99) - (RESTRICTED_ORDER[b.name] ?? 99);
+    return a.display_order - b.display_order;
+  });
+
+  const dotColor = (color: string) => (!color || color === "#000000") ? "#d1d5db" : color;
+
+  if (loading) {
+    return <div className={styles.loadingText}>読み込み中...</div>;
+  }
+
+  return (
+    <div className={styles.container}>
+      {/* Header */}
+      <div className={styles.pageHeader}>
+        <h1 className={styles.pageTitle}>マイロール</h1>
+        <p className={styles.pageSubtitle}>自分のロールを管理できます</p>
+      </div>
+
+      {/* Status */}
+      {status && (
+        <div className={`${styles.statusBanner} ${styles[status.kind]}`}>
+          {status.kind === "success" && "✓ "}
+          {status.kind === "error" && "✕ "}
+          {status.kind === "info" && "ℹ "}
+          {status.msg}
+        </div>
+      )}
+
+      {/* Action bar */}
+      <div className={styles.actionBar}>
+        <SyncButton onSuccess={handleSyncSuccess} onError={handleSyncError} />
+        <PushButton onSuccess={handlePushSuccess} onError={handlePushError} />
+      </div>
+
+      {/* Profile card */}
+      <div className={styles.profileCard}>
+        <div className={styles.profileHeader}>
+          <div className={styles.avatar}>
+            {avatarUrl ? (
+              <img src={avatarUrl} alt={displayName} />
+            ) : (
+              "👤"
+            )}
+          </div>
+          <div>
+            <div className={styles.profileName}>{displayName}</div>
+            <div className={styles.profileSub}>
+              {myDiscordId ? `Discord ID: ${myDiscordId}` : "Discord未連携"}
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.sectionLabel}>現在のロール（{myRoles.length}件）</div>
+
+        {myRoles.length === 0 ? (
+          <div className={styles.emptyRoles}>ロールが割り当てられていません</div>
+        ) : (
+          <div className={styles.myRoles}>
+            {myRoles.map((role) => {
+              return (
+                <div
+                  key={role.role_id}
+                  className={styles.myRoleChip}
+                >
+                  <span className={styles.roleDot} style={{ backgroundColor: dotColor(role.color) }} />
+                  {role.name}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* ロールカテゴリ */}
+      <div className={styles.catalogSection}>
+        <div className={styles.catalogTitle}>ロールカテゴリ</div>
+
+        {sortedCategories.map((cat) => {
+          const catRoles = sortedRoles.filter((r) => r.category_id === cat.id);
+          if (catRoles.length === 0) return null;
+          const isOpen = !collapsedCats.has(cat.id);
+          const catRestricted = RESTRICTED_CATEGORY_NAMES.has(cat.name);
+
+          return (
+            <div key={cat.id} className={styles.catGroup}>
+              <div className={styles.catHeader} onClick={() => toggleCat(cat.id)}>
+                <svg className={`${styles.chevron} ${isOpen ? styles.chevronOpen : ""}`} viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M5.5 3.5L10.5 8l-5 4.5" strokeWidth="1.5" stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <span className={styles.catName}>{cat.name}</span>
+                <span className={styles.catCount}>{catRoles.length}</span>
+                {catRestricted && <span className={styles.catRestricted}>管理者専用</span>}
+              </div>
+
+              {isOpen && (
+                <div className={styles.catRoleList}>
+                  {catRoles.map((role) => {
+                    const assigned = hasRole(role.role_id);
+                    const aboveBot = isAboveBot(role);
+
+                    return (
+                      <div
+                        key={role.role_id}
+                        className={`${styles.catRoleItem} ${aboveBot ? styles.disabledRole : ""}`}
+                      >
+                        <span className={styles.roleDot} style={{ backgroundColor: dotColor(role.color) }} />
+                        <span className={styles.catRoleName}>{role.name}</span>
+                        {aboveBot ? (
+                          <span className={styles.alreadyAssigned}>編集不可</span>
+                        ) : catRestricted ? (
+                          <span className={styles.alreadyAssigned}>変更不可</span>
+                        ) : assigned ? (
+                          <button
+                            type="button"
+                            className={styles.removeRoleBtn}
+                            onClick={() => toggleMyRole(role.role_id)}
+                          >
+                            ✕ 解除
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            className={styles.assignBtn}
+                            onClick={() => toggleMyRole(role.role_id)}
+                          >
+                            ＋ 付与
+                          </button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {/* ロール一覧（閲覧のみ） */}
+        <div className={styles.catGroup}>
+          <div className={styles.catHeader} onClick={() => toggleCat("__all_roles__")}>
+            <svg className={`${styles.chevron} ${!collapsedCats.has("__all_roles__") ? styles.chevronOpen : ""}`} viewBox="0 0 16 16" fill="currentColor">
+              <path d="M5.5 3.5L10.5 8l-5 4.5" strokeWidth="1.5" stroke="currentColor" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            <span className={styles.catName}>ロール一覧</span>
+            <span className={styles.catCount}>{sortedRoles.length}</span>
+          </div>
+
+          {!collapsedCats.has("__all_roles__") && (
+            <div className={styles.catRoleList}>
+              {sortedRoles.map((role) => {
+                const assigned = hasRole(role.role_id);
+                const aboveBot = isAboveBot(role);
+                return (
+                  <div
+                    key={role.role_id}
+                    className={`${styles.catRoleItem} ${aboveBot ? styles.disabledRole : ""}`}
+                  >
+                    <span className={styles.roleDot} style={{ backgroundColor: dotColor(role.color) }} />
+                    <span className={styles.catRoleName}>{role.name}</span>
+                    {assigned && <span className={styles.alreadyAssigned}>付与済み</span>}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Floating save bar */}
+      {hasUnsaved && (
+        <div className={styles.unsavedBar}>
+          <span>未保存の変更があります</span>
+          <button
+            type="button"
+            className={styles.unsavedBarBtn}
+            disabled={saveState === "saving"}
+            onClick={handleSave}
+          >
+            {saveState === "saving" ? "保存中..." : "保存する"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/roles/MemberSelfView.tsx
+++ b/frontend/src/components/roles/MemberSelfView.tsx
@@ -4,7 +4,6 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import SyncButton from "./SyncButton";
 import PushButton from "./PushButton";
 import styles from "./memberself.module.css";
 
@@ -188,13 +187,7 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
     return (membersByRole[roleId] ?? []).includes(myDiscordId);
   }
 
-  // Sync / Push handlers
-  function handleSyncSuccess(count: number) {
-    window.location.href = `/roles?synced=1&roles=${count}&t=${Date.now()}`;
-  }
-  function handleSyncError() {
-    showStatus({ kind: "error", msg: "Discord からの取得に失敗しました" });
-  }
+  // Push handlers
   function handlePushSuccess(result: { updated?: number; created?: number; deleted?: number; reordered?: number }) {
     window.location.href = `/roles?pushed=1&updated=${result.updated ?? 0}&created=${result.created ?? 0}&deleted=${result.deleted ?? 0}&reordered=${result.reordered ?? 0}&t=${Date.now()}`;
   }
@@ -241,7 +234,6 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
 
       {/* Action bar */}
       <div className={styles.actionBar}>
-        <SyncButton onSuccess={handleSyncSuccess} onError={handleSyncError} />
         <PushButton onSuccess={handlePushSuccess} onError={handlePushError} />
       </div>
 

--- a/frontend/src/components/roles/NewRoleModal.tsx
+++ b/frontend/src/components/roles/NewRoleModal.tsx
@@ -1,4 +1,4 @@
-// 役割: 新規ロール作成モーダル
+// 役割: ロール作成・編集モーダル
 
 "use client";
 
@@ -12,7 +12,7 @@ type Category = {
   permissions: number;
 };
 
-type NewRoleData = {
+type RoleData = {
   role_id: string;
   name: string;
   color: string;
@@ -27,10 +27,12 @@ type NewRoleData = {
 type Props = {
   categories: Category[];
   botPermissions: bigint;
-  onCreated: (role: NewRoleData) => void;
+  onSaved: (role: RoleData) => void;
   onClose: () => void;
   isMember?: boolean;
   restrictedCategoryNames?: Set<string>;
+  /** 編集モード: 既存ロールを渡すと編集UIになる */
+  editingRole?: RoleData | null;
 };
 
 // ===== Preset palette (Discord-like) =====
@@ -48,13 +50,18 @@ function setBit(perms: bigint, bit: bigint, value: boolean): bigint {
   return value ? perms | (1n << bit) : perms & ~(1n << bit);
 }
 
-export default function NewRoleModal({ categories, botPermissions, onCreated, onClose, isMember = false, restrictedCategoryNames = new Set() }: Props) {
-  const [name, setName] = useState("");
-  const [color, setColor] = useState("#99AAB5");
-  const [hexInput, setHexInput] = useState("#99AAB5");
-  const [categoryId, setCategoryId] = useState<string | null>(null);
-  const [perms, setPerms] = useState<bigint>(0n);
-  const [isCreating, setIsCreating] = useState(false);
+export default function NewRoleModal({
+  categories, botPermissions, onSaved, onClose,
+  isMember = false, restrictedCategoryNames = new Set(),
+  editingRole = null,
+}: Props) {
+  const isEditMode = !!editingRole;
+
+  const [name, setName] = useState(editingRole?.name ?? "");
+  const [color, setColor] = useState(editingRole?.color ?? "#99AAB5");
+  const [hexInput, setHexInput] = useState(editingRole?.color ?? "#99AAB5");
+  const [categoryId, setCategoryId] = useState<string | null>(editingRole?.category_id ?? null);
+  const [perms, setPerms] = useState<bigint>(BigInt(editingRole?.permissions ?? 0));
   const [error, setError] = useState<string | null>(null);
   const [step, setStep] = useState<"basic" | "permissions">("basic");
 
@@ -62,25 +69,25 @@ export default function NewRoleModal({ categories, botPermissions, onCreated, on
   const hoist = false;
   const mentionable = true;
 
-  // When category changes, inherit its permissions (but member can't set permissions except for 会員情報)
+  // When category changes (新規作成時のみ), inherit its permissions
   useEffect(() => {
+    if (isEditMode) return; // 編集モードではカテゴリ変更で権限は上書きしない
     const cat = categories.find((c) => c.id === categoryId);
     const canSetPermissions = !isMember || cat?.name === "会員情報";
     if (canSetPermissions) {
       setPerms(BigInt(cat?.permissions ?? 0));
     } else {
-      // member: 会員情報以外は権限を常に 0 に固定
       setPerms(0n);
     }
-  }, [categoryId, categories, isMember]);
+  }, [categoryId, categories, isMember, isEditMode]);
 
   // memberモード: 最初の利用可能なカテゴリを自動選択
   useEffect(() => {
-    if (isMember && categoryId === null) {
+    if (isMember && categoryId === null && !isEditMode) {
       const first = categories.find((c) => !restrictedCategoryNames.has(c.name));
       if (first) setCategoryId(first.id);
     }
-  }, [isMember, categories, restrictedCategoryNames, categoryId]);
+  }, [isMember, categories, restrictedCategoryNames, categoryId, isEditMode]);
 
   function handleColorPick(c: string) {
     setColor(c);
@@ -101,45 +108,49 @@ export default function NewRoleModal({ categories, botPermissions, onCreated, on
 
   const isAdminActive = hasBitExact(perms, 3n);
   const botHasAdmin = hasBitExact(botPermissions, 3n);
-  
+
   // member が権限を設定できるかどうか判定
   const selectedCategory = categories.find((c) => c.id === categoryId);
   const canSetPermissions = !isMember || selectedCategory?.name === "会員情報";
 
-  async function handleCreate() {
+  function handleSave() {
     if (!name.trim()) {
       setError("ロール名を入力してください");
       return;
     }
-    // memberモード: カテゴリ必須チェック
     if (isMember && !categoryId) {
       setError("ロールを作成するカテゴリを選択してください");
       return;
     }
     setError(null);
 
-    const draftId = `draft-${Date.now()}`;
-    onCreated({
-      role_id: draftId,
+    const roleId = isEditMode ? editingRole!.role_id : `draft-${Date.now()}`;
+    onSaved({
+      role_id: roleId,
       name: name.trim(),
       color,
       hoist,
       mentionable,
       permissions: Number(perms),
       category_id: categoryId,
-      position: 0, // position will be sorted out locally
+      position: editingRole?.position ?? 0,
+      is_our_bot: editingRole?.is_our_bot,
     });
   }
 
   return (
     <>
       <div className={styles.overlay} onClick={onClose} />
-      <div className={styles.modal} role="dialog" aria-label="新規ロール作成">
+      <div className={styles.modal} role="dialog" aria-label={isEditMode ? "ロール編集" : "新規ロール作成"}>
         {/* Header */}
         <div className={styles.header}>
           <div>
-            <p className={styles.title}>＋ 新規ロールを作成</p>
-            <p className={styles.subtitle}>データベースに下書きとして保存します（Discordへの反映は「送信」を押してください）</p>
+            <p className={styles.title}>{isEditMode ? "✏ ロールを編集" : "＋ 新規ロールを作成"}</p>
+            <p className={styles.subtitle}>
+              {isEditMode
+                ? "変更はローカルに保持されます（Discordへの反映は「送信」を押してください）"
+                : "データベースに下書きとして保存します（Discordへの反映は「送信」を押してください）"}
+            </p>
           </div>
         </div>
 
@@ -317,10 +328,10 @@ export default function NewRoleModal({ categories, botPermissions, onCreated, on
           <button
             type="button"
             className={styles.createBtn}
-            onClick={handleCreate}
+            onClick={handleSave}
             disabled={!name.trim()}
           >
-            作成
+            {isEditMode ? "更新" : "作成"}
           </button>
         </div>
       </div>

--- a/frontend/src/components/roles/RoleAccordion.tsx
+++ b/frontend/src/components/roles/RoleAccordion.tsx
@@ -21,7 +21,6 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import RoleList from "./RoleList";
-import SyncButton from "./SyncButton";
 import PushButton from "./PushButton";
 import MembersPanel from "./MembersPanel";
 import PermissionEditorPanel, { type PermissionTarget } from "./PermissionEditor";
@@ -616,15 +615,6 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     setHasUnsaved(true);
     setSaveState("idle");
   }
-
-  // ===== SyncButton / PushButton =====
-  function handleSyncSuccess(count: number) {
-    // Rely on page reload to fetch the new member data via useEffect on the fresh mount
-    window.location.href = `/roles?synced=1&roles=${count}&t=${Date.now()}`;
-  }
-  function handleSyncError() {
-    showStatus({ kind: "error", msg: "Discord からの取得に失敗しました" });
-  }
   function handlePushSuccess(result: { updated?: number; created?: number; deleted?: number; reordered?: number }) {
     const parts: string[] = [];
     if (result.updated) parts.push(`更新 ${result.updated}`);
@@ -814,7 +804,6 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
             onChange={(e) => setQuery(e.target.value)}
           />
         </div>
-        <SyncButton onSuccess={handleSyncSuccess} onError={handleSyncError} />
         {(isAdmin || isMember) ? <PushButton onSuccess={handlePushSuccess} onError={handlePushError} /> : null}
         {canCreateRole ? (
           <button type="button" className={styles.btnCreate} onClick={() => setShowNewRole(true)}>

--- a/frontend/src/components/roles/RoleAccordion.tsx
+++ b/frontend/src/components/roles/RoleAccordion.tsx
@@ -100,6 +100,7 @@ type SortableCategoryItemProps = {
   onOpenRolePermissions: ((role: Role) => void) | undefined;
   onDeleteRole: ((id: string) => void) | undefined;
   onOpenMemberModal: ((role: Role) => void) | undefined;
+  onEditRole: ((role: Role) => void) | undefined;
   styles: Record<string, string>;
 };
 
@@ -108,7 +109,7 @@ function SortableCategoryItem({
   isAdmin, isMember, isSelectMode, selectedRoleIds, botPosition,
   onToggleCollapse, onOpenCategoryPermissions, onDeleteCategory,
   onToggleSelect, onReorder, onOpenRolePermissions, onDeleteRole,
-  onOpenMemberModal, styles,
+  onOpenMemberModal, onEditRole, styles,
 }: SortableCategoryItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: cat.id });
   const catStyle = {
@@ -199,6 +200,7 @@ function SortableCategoryItem({
           onPermissions={!isSelectMode && isAdmin ? onOpenRolePermissions : undefined}
           onDelete={!isSelectMode && (isAdmin || memberCanManageCat) ? onDeleteRole : undefined}
           onMembers={!isSelectMode && (isAdmin || memberCanManageCat) ? onOpenMemberModal : undefined}
+          onEdit={!isSelectMode && isAdmin ? onEditRole : undefined}
           botPosition={botPosition}
         />
       )}
@@ -228,8 +230,9 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
   // ===== Permission panel =====
   const [permTarget, setPermTarget] = useState<PermissionTarget | null>(null);
 
-  // ===== New role modal =====
+  // ===== New role / edit role modal =====
   const [showNewRole, setShowNewRole] = useState(false);
+  const [editingRole, setEditingRole] = useState<Role | null>(null);
 
   // ===== Member management =====
   const [allMembers, setAllMembers] = useState<Member[]>([]);
@@ -684,32 +687,43 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     setPermTarget(null);
   }
 
-  // ===== New Role creation callback =====
-  function handleRoleCreated(role: {
+  // ===== New Role creation / edit callback =====
+  function handleRoleSaved(role: {
     role_id: string; name: string; color: string;
     hoist: boolean; mentionable: boolean; permissions: number;
     position: number; category_id: string | null; is_our_bot?: boolean;
   }) {
-    // Assign the new role a position that places it at the bottom of editable roles.
-    // Editable roles are those below botPosition (or all roles if no bot found).
-    // Discord positions: higher number = higher in hierarchy. 0 = @everyone.
-    // We want lowest editable position = 1 (just above @everyone).
-    const editableRoles = botPosition !== undefined
-      ? allRoles.filter((r) => r.position < botPosition)
-      : allRoles;
-    const lowestEditablePos = editableRoles.length > 0
-      ? Math.min(...editableRoles.map((r) => r.position))
-      : 1;
-    // Place new role one below the current minimum to put it at the bottom
-    const newPos = Math.max(1, lowestEditablePos - 1);
-    const roleWithPos = { ...role, position: newPos };
-    setAllRoles((prev) => [...prev, roleWithPos]);
-    setShowNewRole(false);
-    showStatus({ kind: "success", msg: `ロール「${role.name}」を作成しました！（保存ボタンで確定）` });
-    // Mark as unsaved so the manifest can be persisted with the new role
+    if (editingRole) {
+      // 編集モード: 既存ロールを更新
+      setAllRoles((prev) =>
+        prev.map((r) => r.role_id === role.role_id ? { ...r, ...role } : r)
+      );
+      setEditingRole(null);
+      setShowNewRole(false);
+      showStatus({ kind: "success", msg: `ロール「${role.name}」を更新しました（保存ボタンで確定）` });
+    } else {
+      // 新規作成モード
+      const editableRoles = botPosition !== undefined
+        ? allRoles.filter((r) => r.position < botPosition)
+        : allRoles;
+      const lowestEditablePos = editableRoles.length > 0
+        ? Math.min(...editableRoles.map((r) => r.position))
+        : 1;
+      const newPos = Math.max(1, lowestEditablePos - 1);
+      const roleWithPos = { ...role, position: newPos };
+      setAllRoles((prev) => [...prev, roleWithPos]);
+      setShowNewRole(false);
+      showStatus({ kind: "success", msg: `ロール「${role.name}」を作成しました！（保存ボタンで確定）` });
+    }
     setHasUnsaved(true);
     setSaveState("idle");
   }
+
+  // ===== Edit role handler =====
+  const handleEditRole = useCallback((role: Role) => {
+    setEditingRole(role);
+    setShowNewRole(true);
+  }, []);
 
   // ===== Member management callbacks =====
   const handleOpenMemberModal = useCallback((role: Role) => {
@@ -897,6 +911,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
                         : undefined
                       : undefined
                   }
+                  onEditRole={!isSelectMode && isAdmin ? handleEditRole : undefined}
                   styles={styles}
                 />
               );
@@ -931,6 +946,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
                   ? handleOpenMemberModalReadOnly
                   : undefined
               }
+              onEdit={!isSelectMode && isAdmin ? handleEditRole : undefined}
               botPosition={botPosition}
             />
           )}
@@ -962,15 +978,16 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
         />
       )}
 
-      {/* New role modal */}
+      {/* New role / edit role modal */}
       {showNewRole && (
         <NewRoleModal
           categories={localCategories}
           botPermissions={botPermissions}
-          onCreated={handleRoleCreated}
-          onClose={() => setShowNewRole(false)}
+          onSaved={handleRoleSaved}
+          onClose={() => { setShowNewRole(false); setEditingRole(null); }}
           isMember={isMember}
           restrictedCategoryNames={RESTRICTED_CATEGORY_NAMES}
+          editingRole={editingRole}
         />
       )}
 

--- a/frontend/src/components/roles/RoleList.tsx
+++ b/frontend/src/components/roles/RoleList.tsx
@@ -39,6 +39,7 @@ type RoleListProps = {
   onPermissions?: (role: RoleItem) => void;
   onDelete?: (roleId: string) => void;
   onMembers?: (role: RoleItem) => void;
+  onEdit?: (role: RoleItem) => void;
   botPosition?: number;
 };
 
@@ -51,6 +52,7 @@ type SortableRoleRowProps = {
   onPermissions?: () => void;
   onDelete?: () => void;
   onMembers?: () => void;
+  onEdit?: () => void;
 };
 
 function DragIcon() {
@@ -83,6 +85,7 @@ function SortableRoleRow({
   onPermissions,
   onDelete,
   onMembers,
+  onEdit,
 }: SortableRoleRowProps) {
   const {
     attributes,
@@ -146,7 +149,7 @@ function SortableRoleRow({
       </div>
 
       {/* Col 3: action buttons */}
-      <div className={styles.roleActionCol} style={{ display: 'flex', gap: '8px', alignItems: 'center', justifyContent: 'flex-end', minWidth: '160px' }}>
+      <div className={styles.roleActionCol} style={{ display: 'flex', gap: '8px', alignItems: 'center', justifyContent: 'flex-end', minWidth: '200px' }}>
         {onMembers && !onToggle && !isDisabled && (
           <button
             type="button"
@@ -156,6 +159,17 @@ function SortableRoleRow({
             title="メンバーを編集"
           >
             メンバー
+          </button>
+        )}
+        {onEdit && !onToggle && !isDisabled && (
+          <button
+            type="button"
+            className={styles.editBtn}
+            onClick={onEdit}
+            aria-label={`${role.name} を編集`}
+            title="ロールを編集"
+          >
+            編集
           </button>
         )}
         {onPermissions && !onToggle && !isDisabled && (
@@ -197,6 +211,7 @@ export default function RoleList({
   onPermissions,
   onDelete,
   onMembers,
+  onEdit,
   botPosition,
 }: RoleListProps) {
   if (roles.length === 0) {
@@ -262,6 +277,9 @@ export default function RoleList({
                 }
                 onMembers={
                   onMembers ? () => onMembers(role) : undefined
+                }
+                onEdit={
+                  onEdit ? () => onEdit(role) : undefined
                 }
               />
             );

--- a/frontend/src/components/roles/memberself.module.css
+++ b/frontend/src/components/roles/memberself.module.css
@@ -1,0 +1,396 @@
+/* ===== Member Self View ===== */
+
+/* Container */
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-weight: 500;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Action bar */
+.actionBar {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+/* Page header */
+.pageHeader {
+  margin-bottom: 24px;
+}
+
+.pageTitle {
+  font-size: 22px;
+  font-weight: 800;
+  color: #0f1117;
+  margin: 0 0 4px;
+}
+
+.pageSubtitle {
+  font-size: 13px;
+  color: #7b8291;
+  margin: 0;
+}
+
+/* Status banner */
+.statusBanner {
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 16px;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.success {
+  background: #ecfdf5;
+  color: #065f46;
+  border: 1px solid #a7f3d0;
+}
+
+.error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+.info {
+  background: #eff6ff;
+  color: #1e40af;
+  border: 1px solid #bfdbfe;
+}
+
+/* Profile card */
+.profileCard {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 24px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+}
+
+.profileHeader {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #e5e7eb;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  color: #6b7280;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profileName {
+  font-size: 16px;
+  font-weight: 700;
+  color: #0f1117;
+}
+
+.profileSub {
+  font-size: 12px;
+  color: #9ca3af;
+  margin-top: 2px;
+}
+
+.sectionLabel {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #9ba3b5;
+  margin-bottom: 10px;
+}
+
+/* My roles list */
+.myRoles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.myRoleChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 10px 0 8px;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  font-size: 13px;
+  font-weight: 500;
+  color: #374151;
+  transition: all 0.15s ease;
+}
+
+.roleDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.removeBtn {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: #9ca3af;
+  font-size: 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+  padding: 0;
+  margin-left: 2px;
+}
+
+.removeBtn:hover {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.restrictedChip {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.emptyRoles {
+  font-size: 13px;
+  color: #9ca3af;
+  padding: 8px 0;
+}
+
+/* Catalog section */
+.catalogSection {
+  margin-top: 24px;
+}
+
+.catalogTitle {
+  font-size: 15px;
+  font-weight: 700;
+  color: #0f1117;
+  margin: 0 0 12px;
+}
+
+/* Category group */
+.catGroup {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  margin-bottom: 10px;
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+}
+
+.catHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.12s;
+}
+
+.catHeader:hover {
+  background: #f9fafb;
+}
+
+.catName {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1f2937;
+  flex: 1;
+}
+
+.catCount {
+  font-size: 12px;
+  color: #9ca3af;
+  background: #f3f4f6;
+  border-radius: 10px;
+  padding: 1px 8px;
+}
+
+.catRestricted {
+  font-size: 10px;
+  color: #ef4444;
+  font-weight: 600;
+  background: #fef2f2;
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
+.chevron {
+  width: 14px;
+  height: 14px;
+  color: #9ca3af;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+}
+
+/* Role item in catalog */
+.catRoleList {
+  border-top: 1px solid #f3f4f6;
+  padding: 4px 0;
+}
+
+.catRoleItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  transition: background 0.12s;
+}
+
+.catRoleItem:hover {
+  background: #f9fafb;
+}
+
+.catRoleName {
+  flex: 1;
+  font-size: 13px;
+  color: #374151;
+}
+
+.assignBtn {
+  height: 26px;
+  padding: 0 12px;
+  border-radius: 14px;
+  border: 1px solid #d1fae5;
+  background: #ecfdf5;
+  color: #059669;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.assignBtn:hover {
+  background: #d1fae5;
+  border-color: #6ee7b7;
+}
+
+.assignBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.alreadyAssigned {
+  font-size: 11px;
+  color: #9ca3af;
+  padding: 4px 10px;
+}
+
+.loadingText {
+  text-align: center;
+  padding: 40px;
+  color: #9ca3af;
+  font-size: 14px;
+}
+
+.disabledRole {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Remove role button (in catalog) */
+.removeRoleBtn {
+  height: 26px;
+  padding: 0 12px;
+  border-radius: 14px;
+  border: 1px solid #fecaca;
+  background: #fef2f2;
+  color: #dc2626;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.removeRoleBtn:hover {
+  background: #fee2e2;
+  border-color: #f87171;
+}
+
+/* Floating save bar */
+.unsavedBar {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 24px;
+  background: #1e293b;
+  color: #f8fafc;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+  font-size: 14px;
+  font-weight: 600;
+  z-index: 100;
+  animation: slideUp 0.25s ease;
+}
+
+@keyframes slideUp {
+  from { transform: translateX(-50%) translateY(20px); opacity: 0; }
+  to   { transform: translateX(-50%) translateY(0); opacity: 1; }
+}
+
+.unsavedBarBtn {
+  height: 36px;
+  padding: 0 20px;
+  border-radius: 8px;
+  border: none;
+  background: #4f46e5;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.unsavedBarBtn:hover:not(:disabled) {
+  background: #4338ca;
+}
+
+.unsavedBarBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/roles/roles.module.css
+++ b/frontend/src/components/roles/roles.module.css
@@ -683,6 +683,36 @@
   height: 14px;
 }
 
+/* Edit button */
+.editBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 26px;
+  padding: 0 9px;
+  border-radius: 6px;
+  border: 1px solid #e8eaef;
+  background: #fff;
+  color: #4a5568;
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+}
+
+.editBtn:hover {
+  background: #fff7ed;
+  color: #c2410c;
+  border-color: #fed7aa;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
+}
+
+.editBtn:active {
+  transform: translateY(0);
+  background: #ffedd5;
+}
+
 /* ===== Diff Confirmation Modal ===== */
 .overlay {
   position: fixed;


### PR DESCRIPTION
## 変更概要

ロール管理画面の修正を行いました。Admin権限者には既存ロールの編集機能を、Member権限者には直感的で安全な自分専用のロール管理UIを提供します。

### 1. Admin機能の拡充: ロール編集機能の追加
これまでロールの新規作成・削除のみ可能でしたが、作成済みロールの編集が可能になりました。

*   **RoleList & RoleAccordionの更新:**
    *   管理者表示の際、ロールのアクション一覧に「編集」ボタンを追加。

### 2. Member機能の刷新: 個人専用のロール管理UI
member権限者には個人のロール着脱にフォーカスした専用のUIを表示するよう切り替えました。

*   **プロフィールと状態の可視化:**
    *   画面上部に自身のDiscordアイコン、表示名と現在の付与ロール一覧（確認用・解除不可）を配置。
    *   操作可能・制限対象・ボット以上のロールを視覚的に判別しやすいようチップスタイルを整理。
*   **階層と制限の厳格化 (Discord仕様への準拠):**
    *   Botと同等以上の権限を持つ上位ロール（"administrator" など）はグレーアウトし操作不能（編集不可）に。
    *   「会員情報」「学年」「学部学科」等の保護カテゴリは「管理者専用/変更不可」として明示し、一般変更をブロック。
    *   カテゴリ順序を最適化し、上部に操作可能なカテゴリ郡、下部に変更不可能な制限カテゴリ群、最下部に読み取り専用の「ロール一覧」が表示される構成へ変更。内部ロールの並び順もDiscordのポジション（Position降順）に統一。
*   **バッチ更新方式の採用 (Adminと同等の操作感):**
    *   ロールの着脱は即時API送信ではなく、ローカルの変更として一旦保持される設計。
    *   変更がある場合のみ画面下部にフローティングバー（「保存する」）が出現し、一括でDBへ保存した後に「↑ Discord へ送信」で反映する従来の方式。
    *   これに伴い `roles.py` バックエンドと Next.js API ルートに `self-remove` エンドポイントを新設。

### 影響範囲
*   **Frontend:** `page.tsx` (ユーザ制御分岐), `MemberSelfView.tsx` (新規作成), `memberself.module.css` (新規), `RoleAccordion.tsx`, `RoleList.tsx`, `NewRoleModal.tsx`, `roles.module.css`
*   **Backend:** `roles.py` (`self-remove` APIエンドポイントの追加)