### PR TITLE
fix: 「Discord」から同期ボタンで表示名も同期させるよう修正

### DIFF
--- a/backend/app/api/v1/roles.py
+++ b/backend/app/api/v1/roles.py
@@ -408,14 +408,21 @@ async def sync_members_from_discord(_principal: dict = Depends(require_admin)) -
 		
 		# Fetch members for each role
 		members_data = {}
+		all_unique_members = {}
 		for role_id in member_role_ids + obog_role_ids + admin_role_ids + ([pre_member_role_id] if pre_member_role_id else []):
 			if role_id:
 				members = await fetch_guild_members_with_role(DISCORD_GUILD_ID, role_id, token)
 				print(f"[DEBUG] Fetched {len(members)} members for role {role_id}")
 				members_data[role_id] = members
+				for m in members:
+					all_unique_members[m["user_id"]] = m
+		
+		print(f"[DEBUG] Saving {len(all_unique_members)} unique guild members metadata")
+		from app.db.repository import save_guild_members
+		await asyncio.to_thread(save_guild_members, list(all_unique_members.values()))
 		
 		# Sync to DB
-		print(f"[DEBUG] Syncing to DB with members_data keys: {list(members_data.keys())}")
+		print(f"[DEBUG] Syncing role memberships to DB with members_data keys: {list(members_data.keys())}")
 		result = await asyncio.to_thread(
 			sync_member_lists,
 			member_role_ids,

--- a/backend/app/services/discord_client.py
+++ b/backend/app/services/discord_client.py
@@ -268,11 +268,13 @@ async def fetch_guild_members_with_role(guild_id: str, role_id: str, token: str)
 						print(f"[DEBUG]   checking if {role_id} in {member_roles}")
 					
 					if str(role_id) in [str(r) for r in member_roles]:
+						user = member.get("user", {})
 						members.append({
-							"user_id": member["user"]["id"],
-							"username": member["user"]["username"],
-							"discriminator": member["user"].get("discriminator", "0"),
-							"display_name": member.get("nick") or member["user"]["username"],
+							"user_id": user.get("id"),
+							"username": user.get("username", ""),
+							"discriminator": user.get("discriminator", "0"),
+							"display_name": member.get("nick") or user.get("global_name") or user.get("username", ""),
+							"avatar": user.get("avatar"),
 						})
 				
 				print(f"[DEBUG] fetch_members: found {len(members)} total so far (checked {total_checked})")


### PR DESCRIPTION
# Discord メンバー同期機能の修正

Discord 上での表示名（Display Name）の変更がウェブアプリケーション側に反映されない問題が解決されました。

## 変更内容

1.  **名前解決ロジックの改善**:
    Discord からメンバーデータを取得する Python ロジックを更新しました。ユーザー名を取得する際、以下の属性の優先順位に従って正確に処理されるようになります。
    * `nick`（サーバー内ニックネーム）
    * `global_name`（Discord システム全体の「表示名」）
    * `username`（固有のユーザー名/ID）

2.  **アバター同期の有効化**:
    同期プロセス中に取得した各メンバーの `avatar` ハッシュを、システムが正しく抽出するようになりました。

3.  **同期時のメタデータ永続化**:
    管理者が「Discord から同期」ボタンをクリックした際、バックエンド API（`/api/v1/roles/members/sync`）がマッピングされたロール全体からすべてのユニークユーザーを抽出するようになりました。更新された名前とアバターは `guild_members` データベーステーブルに保存され、アプリケーション内の情報が安全に最新状態に保たれます。

## 検証内容

* `discord_client.py` 内の修正されたマッピングを確認し、新しい優先順位（`member.get("nick") or user.get("global_name") or user.get("username")`）が適用されていることを確認しました。
* バックエンド API が、抽出されたメタデータ配列を `roles.py` 内の既存の DB テーブル `save_guild_members` へ正しくルーティングしていることを確認しました。

### 動作確認手順
変更を確認するには、テスト用の Discord アカウントで表示名を変更した後、管理画面の「Discord から同期」ボタンを押してください。プロフィール操作を介することなく名前が更新されます。