### PR TITLE
fix: DBへ送信した表示名をフロントエンドに表示

### DIFF
--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.core.auth import get_current_principal
-from app.db.user_repository import find_user_by_sub, is_paid_invitation
+from app.db.user_repository import find_user_by_sub, is_paid_invitation, get_guild_member_info
 
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
@@ -19,6 +19,8 @@ class UserMeResponse(BaseModel):
 	discord_id: str | None
 	app_role: str
 	is_paid: bool = False
+	display_name: str | None = None
+	avatar: str | None = None
 
 
 @router.post("/login-or-register", response_model=UserMeResponse)
@@ -51,14 +53,25 @@ async def get_me(principal: dict = Depends(get_current_principal)) -> UserMeResp
 	app_role = principal.get("app_role", "none")
 
 	paid = False
-	if discord_id and app_role == "none":
-		paid = await asyncio.to_thread(is_paid_invitation, discord_id)
+	display_name = None
+	avatar = None
+	if discord_id:
+		if app_role == "none":
+			paid = await asyncio.to_thread(is_paid_invitation, discord_id)
+		
+		# DBのギルドメンバー情報から最新の表示名を取得
+		member_info = await asyncio.to_thread(get_guild_member_info, discord_id)
+		if member_info:
+			display_name = member_info.get("display_name")
+			avatar = member_info.get("avatar")
 
 	return UserMeResponse(
 		sub=sub,
 		discord_id=discord_id,
 		app_role=app_role,
 		is_paid=paid,
+		display_name=display_name,
+		avatar=avatar,
 	)
 
 

--- a/backend/app/db/user_repository.py
+++ b/backend/app/db/user_repository.py
@@ -226,3 +226,22 @@ def is_paid_invitation(discord_id: str) -> bool:
 				(discord_id,),
 			)
 			return cur.fetchone() is not None
+
+def get_guild_member_info(discord_id: str) -> dict[str, Any] | None:
+	"""discord_id から current profile info を取得する。"""
+	with _connect() as conn:
+		with conn.cursor() as cur:
+			cur.execute(
+				"""
+				SELECT display_name, avatar, username FROM guild_members
+				WHERE user_id = %s
+				""",
+				(discord_id,)
+			)
+			row = cur.fetchone()
+			if row is None:
+				return None
+			return {
+				"display_name": row[0] or row[2],
+				"avatar": row[1]
+			}

--- a/frontend/src/app/(admin)/roles/page.tsx
+++ b/frontend/src/app/(admin)/roles/page.tsx
@@ -9,15 +9,20 @@ import { redirect } from "next/navigation";
 
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8000";
 
-async function resolveUserInfoFromBackend(authorization: string): Promise<{ app_role: string; discord_id: string | null }> {
+async function resolveUserInfoFromBackend(authorization: string): Promise<{ app_role: string; discord_id: string | null; display_name?: string; avatar?: string }> {
 	try {
 		const res = await fetch(`${BACKEND_URL}/api/v1/auth/me`, {
 			headers: { Authorization: authorization },
 			cache: "no-store",
 		});
 		if (res.ok) {
-			const data = (await res.json()) as { app_role?: string; discord_id?: string };
-			return { app_role: data.app_role ?? "none", discord_id: data.discord_id ?? null };
+			const data = (await res.json());
+			return { 
+				app_role: data.app_role ?? "none", 
+				discord_id: data.discord_id ?? null,
+				display_name: data.display_name,
+				avatar: data.avatar
+			};
 		}
 	} catch {
 		// フォールバック
@@ -57,16 +62,17 @@ export default async function RolesPage({ searchParams }: RolesPageProps) {
 		redirect("/login?callbackUrl=%2Froles");
 	}
 
-	const { app_role: role, discord_id: myDiscordId } = await resolveUserInfoFromBackend(authorization);
+	const { app_role: role, discord_id: myDiscordId, display_name: backendName, avatar: backendAvatar } = await resolveUserInfoFromBackend(authorization);
 	const isMember = role === "member";
 
 	const displayName =
+		backendName ??
 		user.user_metadata?.full_name ??
 		user.user_metadata?.name ??
 		user.email ??
 		"不明";
 
-	const avatarUrl: string | null = user.user_metadata?.avatar_url ?? null;
+	const avatarUrl: string | null = backendAvatar ? `https://cdn.discordapp.com/avatars/${myDiscordId}/${backendAvatar}.png` : (user.user_metadata?.avatar_url ?? null);
 
 	let manifest;
 	let accessError: string | null = null;


### PR DESCRIPTION
以前の変更: データベースの中身を古いものから新しいものに更新できるようにした。
今回の変更: フロント側がデータベースを読みに行って、最新の表示名を表示するようにした。