### PR TITLE
feat: 更新処理の簡略化と管理者権限カテゴリ設定機能の追加

### DIFF
--- a/backend/app/api/v1/manifest.py
+++ b/backend/app/api/v1/manifest.py
@@ -21,6 +21,7 @@ class Category(BaseModel):
 	display_order: int = 0
 	is_collapsed: bool = False
 	permissions: int = 0
+	is_restricted: bool = False
 
 
 class Role(BaseModel):
@@ -108,15 +109,16 @@ async def patch_manifest(payload: ManifestPatch, principal: dict = Depends(requi
 	is_admin = principal.get("app_role") == "admin"
 	
 	if not is_admin:
-		# member cannot modify restricted categories.
-		# They can't upsert restricted categories
+		# member は restricted カテゴリを変更・作成できない
 		for c in payload.upsert_categories:
+			# 名前ベースのレガシーガード（後方互換）
 			if c.name in RESTRICTED_CATEGORY_NAMES:
 				raise HTTPException(403, f"Member cannot modify restricted category: {c.name}")
+			# is_restricted フラグで管理者専用を設定することも禁止
+			if c.is_restricted:
+				raise HTTPException(403, "Member cannot create or set admin-only (is_restricted) categories")
 		
-		# For roles, they could assign them to restricted? We only check if they touch any existing or new restricted roles.
-		# (A thorough backend check would fetch the DB to check if deleted category IDs or role IDs belong to restricted names,
-		# but for this simplicity we trust the frontend UI restriction combined with this basic payload check. If needed, can query DB.)
+		# (オプション) 削除対象の restricted カテゴリ保護はフロントエンドUIで制御済み
 		
 	await asyncio.to_thread(
 		patch_manifest_db,

--- a/backend/app/db/repository.py
+++ b/backend/app/db/repository.py
@@ -97,6 +97,18 @@ def init_db() -> None:
                     ALTER TABLE role_categories ADD COLUMN IF NOT EXISTS permissions BIGINT DEFAULT 0;
                     """
                 )
+                # Migration: add is_restricted column (admin-only category flag)
+                cur.execute(
+                    """
+                    ALTER TABLE role_categories ADD COLUMN IF NOT EXISTS is_restricted BOOLEAN DEFAULT FALSE;
+                    """
+                )
+                # Migration: update default restricted categories to TRUE
+                cur.execute(
+                    """
+                    UPDATE role_categories SET is_restricted = TRUE WHERE name IN ('会員情報', '学部学科', '学年');
+                    """
+                )
                 cur.execute(
                     """
                     CREATE TABLE IF NOT EXISTS role_manifests (
@@ -312,7 +324,7 @@ def fetch_manifest() -> dict[str, list[dict[str, Any]]]:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT id, name, display_order, is_collapsed, COALESCE(permissions, 0)
+                SELECT id, name, display_order, is_collapsed, COALESCE(permissions, 0), COALESCE(is_restricted, FALSE)
                 FROM role_categories
                 ORDER BY display_order ASC, name ASC
                 """
@@ -324,6 +336,7 @@ def fetch_manifest() -> dict[str, list[dict[str, Any]]]:
                     "display_order": row[2],
                     "is_collapsed": row[3],
                     "permissions": int(row[4]),
+                    "is_restricted": bool(row[5]),
                 }
                 for row in cur.fetchall()
             ]
@@ -361,8 +374,8 @@ def save_manifest(categories: list[dict[str, Any]], roles: list[dict[str, Any]])
 			for c in categories:
 				cur.execute(
 					"""
-					INSERT INTO role_categories (id, name, display_order, is_collapsed, permissions)
-					VALUES (%s, %s, %s, %s, %s)
+					INSERT INTO role_categories (id, name, display_order, is_collapsed, permissions, is_restricted)
+					VALUES (%s, %s, %s, %s, %s, %s)
 					""",
 					(
 						c["id"],
@@ -370,6 +383,7 @@ def save_manifest(categories: list[dict[str, Any]], roles: list[dict[str, Any]])
 						c.get("display_order", 0),
 						c.get("is_collapsed", False),
 						int(c.get("permissions", 0)),
+						bool(c.get("is_restricted", False)),
 					),
 				)
 
@@ -484,17 +498,19 @@ def patch_manifest_db(
 			for c in upsert_categories:
 				cur.execute(
 					"""
-					INSERT INTO role_categories (id, name, display_order, is_collapsed, permissions)
-					VALUES (%s, %s, %s, %s, %s)
+					INSERT INTO role_categories (id, name, display_order, is_collapsed, permissions, is_restricted)
+					VALUES (%s, %s, %s, %s, %s, %s)
 					ON CONFLICT (id) DO UPDATE SET
 						name = EXCLUDED.name,
 						display_order = EXCLUDED.display_order,
 						is_collapsed = EXCLUDED.is_collapsed,
-						permissions = EXCLUDED.permissions
+						permissions = EXCLUDED.permissions,
+						is_restricted = EXCLUDED.is_restricted
 					""",
 					(
 						c["id"], c["name"], c.get("display_order", 0), 
-						c.get("is_collapsed", False), int(c.get("permissions", 0))
+						c.get("is_collapsed", False), int(c.get("permissions", 0)),
+						bool(c.get("is_restricted", False))
 					),
 				)
 

--- a/frontend/src/actions/manifest.ts
+++ b/frontend/src/actions/manifest.ts
@@ -13,6 +13,7 @@ export type ManifestCategory = {
 	display_order: number;
 	is_collapsed: boolean;
 	permissions: number;
+	is_restricted: boolean;
 };
 
 export type ManifestRole = {

--- a/frontend/src/components/roles/EditCategoryModal.tsx
+++ b/frontend/src/components/roles/EditCategoryModal.tsx
@@ -1,0 +1,97 @@
+// 役割: カテゴリ編集モーダル
+
+"use client";
+
+import { useState } from "react";
+import styles from "./newrole.module.css"; // Reuse new role modal styles
+
+type Category = {
+  id: string;
+  name: string;
+  display_order: number;
+  is_collapsed: boolean;
+  permissions: number;
+  is_restricted: boolean;
+};
+
+type Props = {
+  category: Category;
+  isAdmin: boolean;
+  onSaved: (categoryId: string, name: string, is_restricted: boolean) => void;
+  onClose: () => void;
+};
+
+export default function EditCategoryModal({ category, isAdmin, onSaved, onClose }: Props) {
+  const [name, setName] = useState(category.name);
+  const [isRestricted, setIsRestricted] = useState(category.is_restricted);
+
+  function handleSave() {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onSaved(category.id, trimmed, isRestricted);
+  }
+
+  return (
+    <>
+      <div className={styles.overlay} onClick={onClose} />
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <div>
+            <h2 className={styles.title}>カテゴリの編集</h2>
+            <p className={styles.subtitle}>カテゴリ名や管理者専用設定を変更します</p>
+          </div>
+          <button type="button" className={styles.closeBtn} onClick={onClose}>✕</button>
+        </div>
+
+        <div className={styles.body}>
+          <div className={styles.basicSection}>
+            <label className={styles.fieldLabel}>カテゴリ名 <span className={styles.required}>*</span></label>
+            <input
+              type="text"
+              className={styles.textInput}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="カテゴリ名"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && name.trim()) handleSave();
+              }}
+            />
+
+            {isAdmin && (
+              <div className={styles.toggleRow}>
+                <div>
+                  <div className={styles.toggleLabel}>管理者専用カテゴリ</div>
+                  <div className={styles.toggleDesc}>
+                    オンにすると、メンバーは自分がこのカテゴリ内のロールを付与・解除できなくなります。
+                  </div>
+                </div>
+                <label className={styles.switch}>
+                  <input
+                    type="checkbox"
+                    checked={isRestricted}
+                    onChange={(e) => setIsRestricted(e.target.checked)}
+                  />
+                  <span className={styles.switchSlider} />
+                </label>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className={styles.footer}>
+          {!name.trim() && <div className={styles.errorMsg}>カテゴリ名を入力してください</div>}
+          <button type="button" className={styles.cancelBtn} onClick={onClose}>キャンセル</button>
+          <button
+            type="button"
+            className={styles.createBtn}
+            onClick={handleSave}
+            disabled={!name.trim()}
+          >
+            保存
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/roles/MemberSelfView.tsx
+++ b/frontend/src/components/roles/MemberSelfView.tsx
@@ -1,10 +1,9 @@
 // 役割: Member専用ロール管理ビュー（個人単位）
-// ロール付与/解除はローカルで変更 → 保存 → Discord送信の2ステップ（admin同様）
+// ロール付与/解除はローカルで変更 → 確定時にDB保存+Discord同期を自動実行
 
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import PushButton from "./PushButton";
 import styles from "./memberself.module.css";
 
 type Category = {
@@ -13,6 +12,7 @@ type Category = {
   display_order: number;
   is_collapsed: boolean;
   permissions: number;
+  is_restricted: boolean;
 };
 
 type Role = {
@@ -40,7 +40,6 @@ type Props = {
   avatarUrl: string | null;
 };
 
-const RESTRICTED_CATEGORY_NAMES = new Set(["会員情報", "学部学科", "学年"]);
 
 export default function MemberSelfView({ categories, roles, myDiscordId, displayName, avatarUrl }: Props) {
   const [status, setStatus] = useState<Status | null>(null);
@@ -105,7 +104,7 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
     setSaveState("idle");
   }
 
-  // --- Save to DB (same as admin's persistRoles) ---
+  // --- 確定時にDB保存 + Discord push を一次実行 ---
   async function handleSave() {
     setSaveState("saving");
     try {
@@ -136,6 +135,8 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
         upsert_role_assignments: upsertRoleAssignments,
       };
 
+      // 2. DB保存
+      showStatus({ kind: "info", msg: "DBに保存中..." });
       const res = await fetch("/api/manifest", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -148,10 +149,34 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
         return;
       }
 
+      // ベースラインをリセット（重複保存防止）
+      initialAssignmentsRef.current = JSON.parse(JSON.stringify(membersByRole));
       setHasUnsaved(false);
       setSaveState("saved");
-      showStatus({ kind: "success", msg: "変更を保存しました" });
-      initialAssignmentsRef.current = JSON.parse(JSON.stringify(membersByRole));
+
+      // 3. Discord同期
+      showStatus({ kind: "info", msg: "Discordへ同期中..." });
+      const pushRes = await fetch("/api/roles/push", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const pushBody = (await pushRes.json()) as {
+        ok?: boolean;
+        updated?: number;
+        created?: number;
+        deleted?: number;
+        reordered?: number;
+        errors?: string[];
+      };
+
+      if (!pushRes.ok || !pushBody.ok) {
+        const errMsg = pushBody.errors?.[0] ?? "Discord への送信に失敗しました";
+        showStatus({ kind: "error", msg: `DB保存は完了しましたが、Discordへの送信に失敗しました: ${errMsg}` });
+        return;
+      }
+
+      // 全て成功 → ページリロード
+      window.location.href = `/roles?pushed=1&updated=${pushBody.updated ?? 0}&created=${pushBody.created ?? 0}&deleted=${pushBody.deleted ?? 0}&reordered=${pushBody.reordered ?? 0}&t=${Date.now()}`;
     } catch {
       setSaveState("error");
       showStatus({ kind: "error", msg: "保存に失敗しました。接続を確認してください。" });
@@ -172,10 +197,14 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
     return botPosition !== undefined && role.position >= botPosition;
   }
 
+  // カテゴリのis_restrictedフラグで制限判定
+  const restrictedCategoryIds = new Set(
+    categories.filter(c => c.is_restricted).map(c => c.id)
+  );
+
   function isRestrictedCategory(role: Role): boolean {
     if (!role.category_id) return false;
-    const cat = categories.find((c) => c.id === role.category_id);
-    return cat ? RESTRICTED_CATEGORY_NAMES.has(cat.name) : false;
+    return restrictedCategoryIds.has(role.category_id);
   }
 
   function isRemoveDisabled(role: Role): boolean {
@@ -187,24 +216,16 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
     return (membersByRole[roleId] ?? []).includes(myDiscordId);
   }
 
-  // Push handlers
-  function handlePushSuccess(result: { updated?: number; created?: number; deleted?: number; reordered?: number }) {
-    window.location.href = `/roles?pushed=1&updated=${result.updated ?? 0}&created=${result.created ?? 0}&deleted=${result.deleted ?? 0}&reordered=${result.reordered ?? 0}&t=${Date.now()}`;
-  }
-  function handlePushError(errors?: string[]) {
-    showStatus({ kind: "error", msg: errors?.[0] ?? "Discord への送信に失敗しました" });
-  }
+  // Pushハンドラは削除（handleSave内で自動実行）
 
   // My current roles
   const myRoles = sortedRoles.filter((r) => hasRole(r.role_id));
 
-  // Sort categories: editable first, then restricted (会員情報→学年→学部学科)
-  const RESTRICTED_ORDER: Record<string, number> = { "会員情報": 0, "学年": 1, "学部学科": 2 };
+  // ソート: 編集可能カテゴリを先に、次に制限カテゴリ
   const sortedCategories = [...categories].sort((a, b) => {
-    const aR = RESTRICTED_CATEGORY_NAMES.has(a.name);
-    const bR = RESTRICTED_CATEGORY_NAMES.has(b.name);
+    const aR = a.is_restricted;
+    const bR = b.is_restricted;
     if (aR !== bR) return aR ? 1 : -1;
-    if (aR && bR) return (RESTRICTED_ORDER[a.name] ?? 99) - (RESTRICTED_ORDER[b.name] ?? 99);
     return a.display_order - b.display_order;
   });
 
@@ -232,10 +253,7 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
         </div>
       )}
 
-      {/* Action bar */}
-      <div className={styles.actionBar}>
-        <PushButton onSuccess={handlePushSuccess} onError={handlePushError} />
-      </div>
+      {/* Action bar - PushButtonは自動実行のため非表示 */}
 
       {/* Profile card */}
       <div className={styles.profileCard}>
@@ -284,7 +302,7 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
           const catRoles = sortedRoles.filter((r) => r.category_id === cat.id);
           if (catRoles.length === 0) return null;
           const isOpen = !collapsedCats.has(cat.id);
-          const catRestricted = RESTRICTED_CATEGORY_NAMES.has(cat.name);
+          const catRestricted = cat.is_restricted;
 
           return (
             <div key={cat.id} className={styles.catGroup}>
@@ -374,14 +392,14 @@ export default function MemberSelfView({ categories, roles, myDiscordId, display
       {/* Floating save bar */}
       {hasUnsaved && (
         <div className={styles.unsavedBar}>
-          <span>未保存の変更があります</span>
+          <span>未送信の変更があります</span>
           <button
             type="button"
             className={styles.unsavedBarBtn}
             disabled={saveState === "saving"}
             onClick={handleSave}
           >
-            {saveState === "saving" ? "保存中..." : "保存する"}
+            {saveState === "saving" ? "処理中..." : "変更を確定"}
           </button>
         </div>
       )}

--- a/frontend/src/components/roles/NewRoleModal.tsx
+++ b/frontend/src/components/roles/NewRoleModal.tsx
@@ -30,7 +30,7 @@ type Props = {
   onSaved: (role: RoleData) => void;
   onClose: () => void;
   isMember?: boolean;
-  restrictedCategoryNames?: Set<string>;
+  restrictedCategoryIds?: Set<string>;
   /** 編集モード: 既存ロールを渡すと編集UIになる */
   editingRole?: RoleData | null;
 };
@@ -52,7 +52,7 @@ function setBit(perms: bigint, bit: bigint, value: boolean): bigint {
 
 export default function NewRoleModal({
   categories, botPermissions, onSaved, onClose,
-  isMember = false, restrictedCategoryNames = new Set(),
+  isMember = false, restrictedCategoryIds = new Set(),
   editingRole = null,
 }: Props) {
   const isEditMode = !!editingRole;
@@ -84,10 +84,10 @@ export default function NewRoleModal({
   // memberモード: 最初の利用可能なカテゴリを自動選択
   useEffect(() => {
     if (isMember && categoryId === null && !isEditMode) {
-      const first = categories.find((c) => !restrictedCategoryNames.has(c.name));
+      const first = categories.find((c) => !restrictedCategoryIds.has(c.id));
       if (first) setCategoryId(first.id);
     }
-  }, [isMember, categories, restrictedCategoryNames, categoryId, isEditMode]);
+  }, [isMember, categories, restrictedCategoryIds, categoryId, isEditMode]);
 
   function handleColorPick(c: string) {
     setColor(c);
@@ -111,6 +111,7 @@ export default function NewRoleModal({
 
   // member が権限を設定できるかどうか判定
   const selectedCategory = categories.find((c) => c.id === categoryId);
+  // 会員情報カテゴリのみ権限設定可能（名前は引き継ぎハードコード）
   const canSetPermissions = !isMember || selectedCategory?.name === "会員情報";
 
   function handleSave() {
@@ -148,8 +149,8 @@ export default function NewRoleModal({
             <p className={styles.title}>{isEditMode ? "✏ ロールを編集" : "＋ 新規ロールを作成"}</p>
             <p className={styles.subtitle}>
               {isEditMode
-                ? "変更はローカルに保持されます（Discordへの反映は「送信」を押してください）"
-                : "データベースに下書きとして保存します（Discordへの反映は「送信」を押してください）"}
+                ? "変更を確定すると、DBへの保存とDiscordへの同期が自動で行われます"
+                : "作成を確定すると、DBへの保存とDiscordへの同期が自動で行われます"}
             </p>
           </div>
         </div>
@@ -212,7 +213,7 @@ export default function NewRoleModal({
               >
                 {!isMember && <option value="">カテゴリなし</option>}
                 {categories
-                  .filter((c) => !restrictedCategoryNames.has(c.name))
+                  .filter((c) => !restrictedCategoryIds.has(c.id))
                   .map((c) => (
                     <option key={c.id} value={c.id}>{c.name}</option>
                   ))}

--- a/frontend/src/components/roles/RoleAccordion.tsx
+++ b/frontend/src/components/roles/RoleAccordion.tsx
@@ -21,11 +21,11 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import RoleList from "./RoleList";
-import PushButton from "./PushButton";
 import MembersPanel from "./MembersPanel";
 import PermissionEditorPanel, { type PermissionTarget } from "./PermissionEditor";
 import NewRoleModal from "./NewRoleModal";
 import RoleMemberModal, { type Member } from "./RoleMemberModal";
+import EditCategoryModal from "./EditCategoryModal";
 import styles from "./roles.module.css";
 
 type Category = {
@@ -34,6 +34,7 @@ type Category = {
   display_order: number;
   is_collapsed: boolean;
   permissions: number;
+  is_restricted: boolean;
 };
 
 type Role = {
@@ -100,6 +101,7 @@ type SortableCategoryItemProps = {
   onDeleteRole: ((id: string) => void) | undefined;
   onOpenMemberModal: ((role: Role) => void) | undefined;
   onEditRole: ((role: Role) => void) | undefined;
+  onEditCategory: ((cat: Category) => void) | undefined;
   styles: Record<string, string>;
 };
 
@@ -108,7 +110,7 @@ function SortableCategoryItem({
   isAdmin, isMember, isSelectMode, selectedRoleIds, botPosition,
   onToggleCollapse, onOpenCategoryPermissions, onDeleteCategory,
   onToggleSelect, onReorder, onOpenRolePermissions, onDeleteRole,
-  onOpenMemberModal, onEditRole, styles,
+  onOpenMemberModal, onEditRole, onEditCategory, styles,
 }: SortableCategoryItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: cat.id });
   const catStyle = {
@@ -145,16 +147,27 @@ function SortableCategoryItem({
         <span className={styles.groupCount}>{catRoles.length}</span>
 
         {isAdmin ? (
-          <button
-            type="button"
-            className={styles.catPermBtn}
-            onClick={(e) => { e.stopPropagation(); onOpenCategoryPermissions(cat); }}
-            title="カテゴリ権限設定"
-            aria-label={`${cat.name} の権限設定`}
-          >
-            <ShieldIcon />
-            権限
-          </button>
+          <>
+            <button
+              type="button"
+              className={styles.catPermBtn}
+              onClick={(e) => { e.stopPropagation(); if (onEditCategory) onEditCategory(cat); }}
+              title="カテゴリ編集"
+              aria-label={`${cat.name} を編集`}
+            >
+              編集
+            </button>
+            <button
+              type="button"
+              className={styles.catPermBtn}
+              onClick={(e) => { e.stopPropagation(); onOpenCategoryPermissions(cat); }}
+              title="カテゴリ権限設定"
+              aria-label={`${cat.name} の権限設定`}
+            >
+              <ShieldIcon />
+              権限
+            </button>
+          </>
         ) : null}
 
         {/* member: ロールが残っている場合は削除不可。admin: 制限なし */}
@@ -221,6 +234,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
   const [selectedRoleIds, setSelectedRoleIds] = useState<Set<string>>(new Set());
   const [isSelectMode, setIsSelectMode] = useState(false);
   const [newCategoryName, setNewCategoryName] = useState("");
+  const [newCategoryRestricted, setNewCategoryRestricted] = useState(false);
 
   // Status banner
   const [status, setStatus] = useState<Status | null>(null);
@@ -229,9 +243,10 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
   // ===== Permission panel =====
   const [permTarget, setPermTarget] = useState<PermissionTarget | null>(null);
 
-  // ===== New role / edit role modal =====
+  // ===== New role / edit role / edit category modal =====
   const [showNewRole, setShowNewRole] = useState(false);
   const [editingRole, setEditingRole] = useState<Role | null>(null);
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
 
   // ===== Member management =====
   const [allMembers, setAllMembers] = useState<Member[]>([]);
@@ -258,8 +273,10 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
   const canManageMembers = isAdmin;
   const canEditManifest = isAdmin || isMember;
 
-  // memberモードでロール付与を禁止するカテゴリ名
-  const RESTRICTED_CATEGORY_NAMES = new Set(["\u4f1a\u54e1\u60c5\u5831", "\u5b66\u90e8\u5b66\u79d1", "\u5b66\u5e74"]);
+  // memberモードでロール付与を禁止するカテゴリ（is_restrictedフラグで判定）
+  const restrictedCategoryIds = new Set(
+    localCategories.filter(c => c.is_restricted).map(c => c.id)
+  );
 
   function showStatus(s: Status, durationMs = 5000) {
     setStatus(s);
@@ -411,7 +428,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     setShowDiffModal(true);
   }
 
-  // ===== Execute save (called after diff confirmation) =====
+  // ===== Execute save + Discord push (called after diff confirmation) =====
   async function executeSave() {
     if (!pendingRoles || !pendingCats) return;
     
@@ -425,16 +442,16 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     try {
       // 1. Calculate Diff
       const upsertCategories = pendingCats.filter(c => {
-        const init = initCategories.find(i => i.id === c.id);
+        const init = baseCategories.find(i => i.id === c.id);
         return !init || JSON.stringify(init) !== JSON.stringify(c);
       });
-      const deleteCatIds = initCategories.filter(c => !pendingCats.find(n => n.id === c.id)).map(c => c.id);
+      const deleteCatIds = baseCategories.filter(c => !pendingCats.find(n => n.id === c.id)).map(c => c.id);
 
       const upsertRoles = pendingRoles.filter(r => {
-        const init = initRoles.find(i => i.role_id === r.role_id);
+        const init = baseRoles.find(i => i.role_id === r.role_id);
         return !init || JSON.stringify(init) !== JSON.stringify(r);
       });
-      const deleteRoleIds = initRoles.filter(r => !pendingRoles.find(n => n.role_id === r.role_id)).map(r => r.role_id);
+      const deleteRoleIds = baseRoles.filter(r => !pendingRoles.find(n => n.role_id === r.role_id)).map(r => r.role_id);
 
       const upsertRoleAssignments: Record<string, string[]> = {};
       const initAssignments = initialAssignmentsRef.current;
@@ -445,8 +462,6 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
           upsertRoleAssignments[roleId] = membersByRole[roleId];
         }
       }
-      // また、初期状態で存在していたが、UI上ですべて消された（キー自体が空の配列として必要、またはキーが消えた）場合への対応として
-      // 実際には membersByRole の更新で空配列 [] として残るので上書きされるため上記でOK。
 
       const payload = {
         upsert_categories: upsertCategories,
@@ -476,6 +491,8 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
         return;
       }
 
+      // 2. DB保存（PATCH /api/manifest）
+      showStatus({ kind: "info", msg: "DBに保存中..." });
       const res = await fetch("/api/manifest", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
@@ -483,7 +500,6 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       });
 
       if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}));
         setSaveState("error");
         showStatus({ kind: "error", msg: "保存に失敗しました。再度お試しください。" });
         setPendingRoles(null);
@@ -491,14 +507,38 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
         return;
       }
 
+      // 3. 保存成功: ベースラインをリセット（重複保存防止）
+      setBaseRoles(pendingRoles);
+      setBaseCategories(pendingCats);
+      initialAssignmentsRef.current = JSON.parse(JSON.stringify(membersByRole));
       setHasUnsaved(false);
       setSaveState("saved");
-      showStatus({ kind: "success", msg: "変更を保存しました" });
       setPendingRoles(null);
       setPendingCats(null);
-      
-      // Update our init references to match current
-      initialAssignmentsRef.current = JSON.parse(JSON.stringify(membersByRole));
+
+      // 4. Discord同期（POST /api/roles/push）
+      showStatus({ kind: "info", msg: "Discordへ同期中..." });
+      const pushRes = await fetch("/api/roles/push", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      const pushBody = (await pushRes.json()) as {
+        ok?: boolean;
+        updated?: number;
+        created?: number;
+        deleted?: number;
+        reordered?: number;
+        errors?: string[];
+      };
+
+      if (!pushRes.ok || !pushBody.ok) {
+        const errMsg = pushBody.errors?.[0] ?? "Discord への送信に失敗しました";
+        showStatus({ kind: "error", msg: `DB保存は完了しましたが、Discordへの送信に失敗しました: ${errMsg}` });
+        return;
+      }
+
+      // 5. 全て成功 → ページリロード
+      window.location.href = `/roles?pushed=1&updated=${pushBody.updated ?? 0}&created=${pushBody.created ?? 0}&deleted=${pushBody.deleted ?? 0}&reordered=${pushBody.reordered ?? 0}&t=${Date.now()}`;
     } catch {
       setSaveState("error");
       showStatus({ kind: "error", msg: "保存に失敗しました。接続を確認してください。" });
@@ -540,6 +580,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     setIsSelectMode((v) => !v);
     setSelectedRoleIds(new Set());
     setNewCategoryName("");
+    setNewCategoryRestricted(false);
   }
 
   function toggleSelectRole(id: string) {
@@ -555,7 +596,14 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     const name = newCategoryName.trim();
     if (!name) return;
     const newCatId = `cat_${Date.now()}`;
-    const newCat: Category = { id: newCatId, name, display_order: localCategories.length, is_collapsed: false, permissions: 0 };
+    const newCat: Category = {
+      id: newCatId,
+      name,
+      display_order: localCategories.length,
+      is_collapsed: false,
+      permissions: 0,
+      is_restricted: newCategoryRestricted,
+    };
     const updatedRoles = allRoles.map((r) => selectedRoleIds.has(r.role_id) ? { ...r, category_id: newCatId } : r);
     const nextCats = [...localCategories, newCat];
     setLocalCategories(nextCats);
@@ -563,9 +611,25 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     setSelectedRoleIds(new Set());
     setIsSelectMode(false);
     setNewCategoryName("");
+    setNewCategoryRestricted(false);
     setHasUnsaved(true);
     setSaveState("idle");
-    showStatus({ kind: "info", msg: `カテゴリ「${name}」を作成しました（保存ボタンで確定）` });
+    const restrictedLabel = newCategoryRestricted ? "（管理者専用）" : "";
+    showStatus({ kind: "info", msg: `カテゴリ「${name}」${restrictedLabel}を作成しました。「変更を確定」で保存してDiscordに同期します` });
+  }
+
+  function handleEditCategorySaved(catId: string, newName: string, newIsRestricted: boolean) {
+    setLocalCategories((prev) =>
+      prev.map((c) =>
+        c.id === catId
+          ? { ...c, name: newName, is_restricted: newIsRestricted }
+          : c
+      )
+    );
+    setEditingCategory(null);
+    setHasUnsaved(true);
+    setSaveState("idle");
+    showStatus({ kind: "info", msg: `カテゴリ「${newName}」を更新しました。「変更を確定」で保存してDiscordに同期します` });
   }
 
   function deleteCategory(catId: string) {
@@ -581,7 +645,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     setAllRoles((prev) => prev.map((r) => r.category_id === catId ? { ...r, category_id: null } : r));
     setHasUnsaved(true);
     setSaveState("idle");
-    showStatus({ kind: "info", msg: "カテゴリを削除しました。属していたロールは「未分類」に移動しました（保存ボタンで確定）" });
+    showStatus({ kind: "info", msg: "カテゴリを削除しました。属していたロールは「未分類」に移動しました。「変更を確定」で保存してDiscordに同期します" });
   }
 
   function deleteRole(roleId: string) {
@@ -603,7 +667,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     setAllRoles((prev) => prev.filter((r) => r.role_id !== roleId));
     setHasUnsaved(true);
     setSaveState("idle");
-    showStatus({ kind: "info", msg: "ロールを削除しました（保存ボタンで確定）" });
+    showStatus({ kind: "info", msg: "ロールを削除しました。「変更を確定」で保存してDiscordに同期します" });
   }
 
   // カテゴリの並び替え（DnD完了時）
@@ -614,22 +678,6 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     });
     setHasUnsaved(true);
     setSaveState("idle");
-  }
-  function handlePushSuccess(result: { updated?: number; created?: number; deleted?: number; reordered?: number }) {
-    const parts: string[] = [];
-    if (result.updated) parts.push(`更新 ${result.updated}`);
-    if (result.created) parts.push(`作成 ${result.created}`);
-    if (result.deleted) parts.push(`削除 ${result.deleted}`);
-    if (result.reordered) parts.push(`並び替え ${result.reordered}`);
-    const detail = parts.length ? `（${parts.join(" / ")}）` : "";
-    window.location.href = `/roles?pushed=1&updated=${result.updated ?? 0}&created=${result.created ?? 0}&deleted=${result.deleted ?? 0}&reordered=${result.reordered ?? 0}&t=${Date.now()}`;
-  }
-  function handlePushError(errors?: string[]) {
-    if (errors && errors.length > 0) {
-      showStatus({ kind: "error", msg: `Discord への送信エラー: ${errors[0]}` });
-    } else {
-      showStatus({ kind: "error", msg: "Discord への送信に失敗しました" });
-    }
   }
 
   // ===== Permission panel callbacks =====
@@ -665,12 +713,12 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       setAllRoles((prev) =>
         prev.map((r) => r.category_id === permTarget.id ? { ...r, permissions: newPermissions } : r)
       );
-      showStatus({ kind: "info", msg: `カテゴリ「${permTarget.name}」の権限をカテゴリ内ロールに適用しました（保存ボタンで確定）` });
+      showStatus({ kind: "info", msg: `カテゴリ「${permTarget.name}」の権限をカテゴリ内ロールに適用しました。「変更を確定」で保存してDiscordに同期します` });
     } else {
       setAllRoles((prev) =>
         prev.map((r) => r.role_id === permTarget.id ? { ...r, permissions: newPermissions } : r)
       );
-      showStatus({ kind: "info", msg: `ロール「${permTarget.name}」の権限を更新しました（保存ボタンで確定）` });
+      showStatus({ kind: "info", msg: `ロール「${permTarget.name}」の権限を更新しました。「変更を確定」で保存してDiscordに同期します` });
     }
     setHasUnsaved(true);
     setSaveState("idle");
@@ -690,7 +738,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       );
       setEditingRole(null);
       setShowNewRole(false);
-      showStatus({ kind: "success", msg: `ロール「${role.name}」を更新しました（保存ボタンで確定）` });
+      showStatus({ kind: "success", msg: `ロール「${role.name}」を更新しました。「変更を確定」で保存してDiscordに同期します` });
     } else {
       // 新規作成モード
       const editableRoles = botPosition !== undefined
@@ -703,7 +751,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       const roleWithPos = { ...role, position: newPos };
       setAllRoles((prev) => [...prev, roleWithPos]);
       setShowNewRole(false);
-      showStatus({ kind: "success", msg: `ロール「${role.name}」を作成しました！（保存ボタンで確定）` });
+      showStatus({ kind: "success", msg: `ロール「${role.name}」を追加しました。「変更を確定」で保存してDiscordに同期します` });
     }
     setHasUnsaved(true);
     setSaveState("idle");
@@ -738,15 +786,15 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     setHasUnsaved(true);
     setSaveState("idle");
     const detail = `付与 ${add.length}名 / 削除 ${remove.length}名`;
-    showStatus({ kind: "success", msg: `メンバー割り当てを変更しました（${detail}）（保存ボタンで確定）` });
+    showStatus({ kind: "success", msg: `メンバー割り当てを変更しました（${detail}）。「変更を確定」で保存してDiscordに同期します` });
   }
 
   // ===== Self-assign (member mode) =====
   const handleSelfAssign = useCallback(async (role: Role) => {
-    // 禁止カテゴリチェック
-    const cat = localCategories.find((c) => c.id === role.category_id);
-    if (cat && RESTRICTED_CATEGORY_NAMES.has(cat.name)) {
-      showStatus({ kind: "error", msg: `「${cat.name}」カテゴリのロールは付与できません` });
+    // 禁止カテゴリチェック（is_restrictedフラグで判定）
+    if (role.category_id && restrictedCategoryIds.has(role.category_id)) {
+      const cat = localCategories.find((c) => c.id === role.category_id);
+      showStatus({ kind: "error", msg: `「${cat?.name ?? ""}」カテゴリのロールは付与できません` });
       return;
     }
     try {
@@ -764,7 +812,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
     } catch {
       showStatus({ kind: "error", msg: "ロールの付与に失敗しました。接続を確認してください" });
     }
-  }, [localCategories, RESTRICTED_CATEGORY_NAMES]);
+  }, [localCategories, restrictedCategoryIds]);
 
   const categoryIds = new Set(localCategories.map((c) => c.id));
   const uncategorizedRoles = filteredRoles.filter((r) => !r.category_id || !categoryIds.has(r.category_id));
@@ -804,7 +852,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
             onChange={(e) => setQuery(e.target.value)}
           />
         </div>
-        {(isAdmin || isMember) ? <PushButton onSuccess={handlePushSuccess} onError={handlePushError} /> : null}
+        {/* PushButton は executeSave() 内で自動呼出しされるため非表示 */}
         {canCreateRole ? (
           <button type="button" className={styles.btnCreate} onClick={() => setShowNewRole(true)}>
             + ロール作成
@@ -843,6 +891,16 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
             onChange={(e) => setNewCategoryName(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") createCategory(); }}
           />
+          {isAdmin && (
+            <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, whiteSpace: "nowrap", cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={newCategoryRestricted}
+                onChange={(e) => setNewCategoryRestricted(e.target.checked)}
+              />
+              管理者専用
+            </label>
+          )}
           <button type="button" className={styles.btnPrimary} onClick={createCategory}
             disabled={!newCategoryName.trim()}>
             作成
@@ -869,7 +927,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
             {localCategories.map((cat) => {
               const catRoles = filteredRoles.filter((r) => r.category_id === cat.id);
               const isOpen = !collapsedIds.has(cat.id);
-              const isRestrictedCat = RESTRICTED_CATEGORY_NAMES.has(cat.name);
+              const isRestrictedCat = cat.is_restricted;
               const memberCanManageCat = isMember && !isRestrictedCat;
               return (
                 <SortableCategoryItem
@@ -901,6 +959,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
                       : undefined
                   }
                   onEditRole={!isSelectMode && isAdmin ? handleEditRole : undefined}
+                  onEditCategory={!isSelectMode && isAdmin ? setEditingCategory : undefined}
                   styles={styles}
                 />
               );
@@ -945,14 +1004,14 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
       {/* Floating save bar */}
       {hasUnsaved && (
         <div className={styles.unsavedBar}>
-          <span>未保存の変更があります</span>
+          <span>未送信の変更があります</span>
           <button
             type="button"
             className={styles.unsavedBarBtn}
             disabled={saveState === "saving" || !canEditManifest}
             onClick={() => persistRoles(allRoles, localCategories)}
           >
-            {saveState === "saving" ? "保存中..." : canEditManifest ? "保存する" : "保存不可"}
+            {saveState === "saving" ? "処理中..." : canEditManifest ? "変更を確定" : "操作不可"}
           </button>
         </div>
       )}
@@ -975,8 +1034,18 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
           onSaved={handleRoleSaved}
           onClose={() => { setShowNewRole(false); setEditingRole(null); }}
           isMember={isMember}
-          restrictedCategoryNames={RESTRICTED_CATEGORY_NAMES}
+          restrictedCategoryIds={restrictedCategoryIds}
           editingRole={editingRole}
+        />
+      )}
+
+      {/* Edit Category Modal */}
+      {editingCategory && (
+        <EditCategoryModal
+          category={editingCategory}
+          isAdmin={isAdmin}
+          onSaved={handleEditCategorySaved}
+          onClose={() => setEditingCategory(null)}
         />
       )}
 
@@ -1011,7 +1080,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
           <div className={styles.modal} role="dialog" aria-label="変更内容確認">
             <div className={styles.header}>
               <p className={styles.title}>変更内容の確認</p>
-              <p className={styles.subtitle}>以下の変更を保存します</p>
+              <p className={styles.subtitle}>以下の変更をDBに保存し、Discordへ同期します</p>
             </div>
             <div style={{ maxHeight: '400px', overflowY: 'auto', padding: '20px', fontSize: '14px', borderBottom: '1px solid #e5e7eb' }}>
               {(diffData.roleAdded.length > 0 || diffData.memberAssigned.length > 0 || diffData.permissionEdited.length > 0 || diffData.orderChanged.length > 0 || diffData.roleDeleted.length > 0 || diffData.categoriesAdded.length > 0 || diffData.categoriesDeleted.length > 0) ? (
@@ -1135,7 +1204,7 @@ export default function RoleAccordion({ categories: initCategories, roles: initR
                 className={styles.confirmBtn}
                 onClick={executeSave}
               >
-                保存する
+                保存してDiscordへ送信
               </button>
             </div>
           </div>


### PR DESCRIPTION
## 概要
ロール管理フローの簡略化（保存とDiscord同期のワンアクション化）と、Discordロール管理における「管理者専用カテゴリ」の動的な設定機能を実装

## 変更内容

### 1. ロール管理フローの統合
* 管理者/メンバーどちらのロール管理画面 (`MemberSelfView`) においても「DB保存」から「Discord送信」までを一括で行うフローへと統合しました。
* 変更後に「変更を確定」ボタンを押すことで、DBへの保存とDiscordへの同期が連続して自動実行され、完了後に画面が自動リロードされます。これに伴い、個別のDiscord送信ボタン (`PushButton`) を廃止しました。

### 2. 管理者専用（制限付き）カテゴリ機能の動的化
従来のソースコード内でのカテゴリ名ハードコードによる制限を廃止し、データベースのフラグ管理へと移行しました。これにより、管理者専用カテゴリとしてのフラグが立っているカテゴリに属するロールらは、member権限ログイン状態では付与・削除できないようになりました。

* **データベース/バックエンド:**
  * `role_categories` テーブルに `is_restricted` (管理者専用フラグ) カラムを追加しました。
  * 新規データベース初期化時、および既存DBのアップデート時に、デフォルトの制限カテゴリ（`会員情報`、`学部学科`、`学年`）のフラグが自動で `TRUE` になるマイグレーションスクリプトを実装しました。
  * `PATCH /api/manifest` API エンドポイントにおいて、一般メンバーが `is_restricted` を書き換えたり、制限付きカテゴリを追加・修正したりすることを防ぐバリデーションを追加しました。
* **フロントエンド:**
  * 新規カテゴリ作成時に「管理者専用」とするかを選択できるトグルUIを追加しました（管理者のみ表示）。
  
<img width="500" alt="image" src="https://github.com/user-attachments/assets/12c7b264-ba5f-4c97-bc09-d2937f62b718" />

  * 既存のカテゴリに対しても「編集」ボタンを追加し、カテゴリ名の変更や「管理者専用」フラグのON/OFFを切り替えられるモーダル画面 (`EditCategoryModal`) を新たに実装しました。
 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/6512280c-007d-4f43-a054-2cdd7dfa835a" />

  * メンバーのセルフロール管理画面において、`is_restricted` フラグが `TRUE` のカテゴリ内のロールについて、メンバーが自身で付与・解除操作を行えないよう制限を行いました。（前述と同義）
